### PR TITLE
create new method to retrieve a list of rejected variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 # gedit backup files
 *~
+
+# remove pycharm boilerplate files
+.idea

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Start by loading in your pandas DataFrame, e.g. by using
 To display the report in a Jupyter notebook, run:
 
 	pandas_profiling.ProfileReport(df)
+	
+To retrieve the list of variables which are rejected due to high correlation:
+
+    profile = pandas_profiling.ProfileReport(df)
+    rejected_variables = profile.get_rejected_variables(threshold=0.9)
 
 If you want to generate a HTML report file, save the ProfileReport to an object and use the *to_file()* function:
 

--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -16,8 +16,26 @@ class ProfileReport(object):
         sample = kwargs.get('sample', df.head())
 
         description_set = describe(df, **kwargs)
+
         self.html = to_html(sample,
                             description_set)
+
+        self.description_set = description_set
+
+    def get_description(self):
+        return self.description_set
+
+    def get_rejected_variables(self, threshold=0.9):
+        """ return a list of variable names being rejected for high
+            correlation with one of remaining variables
+
+            Parameters:
+            ----------
+            threshold: float (optional)
+                correlation value which is above the threshold are rejected
+        """
+        variable_profile = self.description_set['variables']
+        return variable_profile.index[variable_profile.correlation > threshold].tolist()
 
     def to_file(self, outputfile=DEFAULT_OUTPUTFILE):
 


### PR DESCRIPTION
- create new method get_rejected_variables() to output rejected variable (default threhold is 0.90, which is same with the threshold generated in html report)
- add usage code example of the added method in README.md
- update .gitignore to ignore files generated by pycharm
