### PR TITLE
Add support for numpy infinite values

### DIFF
--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -140,16 +140,27 @@ def describe(df, **kwargs):
         return pd.Series(['UNIQUE'], index=['type'], name=data.name)
 
     def describe_1d(data):
-        count = data.count()
-        leng = len(data)
-        distinct_count = data.nunique(dropna=False)
+        leng = len(data)  # number of observations in the Series
+        count = data.count()  # number of non-NaN observations in the Series
+
+        # Replace infinite values with NaNs to avoid issues with
+        # histograms later.
+        data.replace(to_replace=[np.inf, np.NINF, np.PINF], value=np.nan, inplace=True)
+
+        n_infinite = count - data.count()  # number of infinte observations in the Series
+        
+        distinct_count = data.nunique(dropna=False)  # number of unique elements in the Series
         if count > distinct_count > 1:
             mode = data.mode().iloc[0]
         else:
             mode = data[0]
 
-        results_data = {'count': count, 'distinct_count': distinct_count, 'p_missing': 1 - count / leng,
+        results_data = {'count': count,
+                        'distinct_count': distinct_count,
+                        'p_missing': 1 - count / leng,
                         'n_missing': leng - count,
+                        'p_infinite': n_infinite / leng,
+                        'n_infinite': n_infinite,
                         'is_unique': distinct_count == leng,
                         'mode': mode,
                         'p_unique': distinct_count / count}

--- a/pandas_profiling/formatters.py
+++ b/pandas_profiling/formatters.py
@@ -40,6 +40,7 @@ def fmt_varname(v):
 value_formatters={
         u'freq': (lambda v: gradient_format(v, 0, 62000, (30, 198, 244), (99, 200, 72))),
         u'p_missing': fmt_percent,
+        u'p_infinite': fmt_percent,
         u'p_unique': fmt_percent,
         u'p_zeros': fmt_percent,
         u'memorysize': fmt_bytesize,
@@ -63,6 +64,7 @@ def fmt_skewness(v):
 row_formatters={
     u'p_zeros': fmt_row_severity,
     u'p_missing': fmt_row_severity,
+    u'p_infinite': fmt_row_severity,
     u'n_duplicates': fmt_row_severity,
     u'skewness': fmt_skewness,
 }

--- a/pandas_profiling/templates.py
+++ b/pandas_profiling/templates.py
@@ -343,6 +343,10 @@ row_templates_dict['NUM'] = _row_header.format(vartype="Numeric", varname="{0[va
                         <td>{0[p_missing]}</td></tr>
                         <tr class="{row_classes[p_missing]}"><th>Missing (n)</th>
                         <td>{0[n_missing]}</td></tr>
+                        <tr class="{row_classes[p_infinite]}"><th>Infinite (%)</th>
+                        <td>{0[p_infinite]}</td></tr>
+                        <tr class="{row_classes[p_infinite]}"><th>Infinite (n)</th>
+                        <td>{0[n_infinite]}</td></tr>
                     </table>
 
                 </div>
@@ -432,6 +436,10 @@ row_templates_dict['DATE'] = _row_header.format(vartype="Date", varname="{0[varn
                 <td>{0[p_missing]}</td></tr>
                 <tr class="{row_classes[p_missing]}"><th>Missing (n)</th>
                 <td>{0[n_missing]}</td></tr>
+                <tr class="{row_classes[p_infinite]}"><th>Infinite (%)</th>
+                <td>{0[p_infinite]}</td></tr>
+                <tr class="{row_classes[p_infinite]}"><th>Infinite (n)</th>
+                <td>{0[n_infinite]}</td></tr>
             </table>
         </div>
         <div class="col-sm-6">
@@ -460,6 +468,10 @@ row_templates_dict['CAT'] = _row_header.format(vartype="Categorical", varname="{
                 <td>{0[p_missing]}</td></tr>
                 <tr class="{row_classes[p_missing]}"><th>Missing (n)</th>
                 <td>{0[n_missing]}</td></tr>
+                <tr class="{row_classes[p_infinite]}"><th>Infinite (%)</th>
+                <td>{0[p_infinite]}</td></tr>
+                <tr class="{row_classes[p_infinite]}"><th>Infinite (n)</th>
+                <td>{0[n_infinite]}</td></tr>
             </table>
 
 
@@ -570,6 +582,7 @@ messages['HIGH_CARDINALITY'] = u'{varname} has a high cardinality: {0[distinct_c
 messages['n_duplicates'] = u'Dataset has {0[n_duplicates]} duplicate rows <span class="label label-warning">Warning</span>'
 messages['skewness'] = u'{varname} is highly skewed (γ1 = {0[skewness]})'
 messages['p_missing'] = u'{varname} has {0[n_missing]} / {0[p_missing]} missing values <span class="label label-default">Missing</span>'
+messages['p_infinite'] = u'{varname} has {0[n_infinite]} / {0[p_infinite]} infinite values <span class="label label-default">Infinite</span>'
 messages['p_zeros'] = u'{varname} has {0[n_zeros]} / {0[p_zeros]} zeros'
 
 message_row = u'<li>{message}</l>'

--- a/pandas_profiling/tests.py
+++ b/pandas_profiling/tests.py
@@ -44,21 +44,21 @@ class DataFrameTest(unittest.TestCase):
     def test_describe_df(self):
 
         expected_results = {}
-        expected_results['id'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 9,
+        expected_results['id'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 9, 'n_infinite': 0, 'p_infinite': 0,
                                   'cv': check_is_NaN, 'distinct_count': 9, 'freq': check_is_NaN, 'histogram': check_is_NaN, 'iqr': check_is_NaN,
                                   'is_unique': True, 'kurtosis': check_is_NaN, 'mad': check_is_NaN, 'max': check_is_NaN, 'mean': check_is_NaN,
                                   'min': check_is_NaN, 'mini_histogram': check_is_NaN, 'n_missing': 0, 'p_missing': 0.0,
                                   'p_unique': 1.0, 'p_zeros': check_is_NaN, 'range': check_is_NaN, 'skewness': check_is_NaN,
                                   'std': check_is_NaN, 'sum': check_is_NaN, 'top': check_is_NaN, 'type': 'UNIQUE', 'variance': check_is_NaN}
         expected_results['x'] = {'25%': -0.75, '5%': -7.5499999999999989, '50%': 2.5, '75%': 23.75, '95%': 50.0,
-                                 'count': 8, 'cv': 1.771071190261633, 'distinct_count': 7, 'freq': check_is_NaN, 'iqr': 24.5,
+                                 'count': 8, 'n_infinite': 0, 'p_infinite': 0, 'cv': 1.771071190261633, 'distinct_count': 7, 'freq': check_is_NaN, 'iqr': 24.5,
                                  'is_unique': False, 'kurtosis': -0.50292858929003803, 'mad': 18.71875, 'max': 50.0,
                                  'mean': 13.375, 'min': -10.0, 'mode': 0.0, 'n_missing': 1,
                                  'p_missing': 0.11111111111111116, 'p_unique': 0.875, 'p_zeros': 0.2222222222222222,
                                  'range': 60.0, 'skewness': 1.0851622393567653, 'std': 23.688077169749342, 'sum': 107.0,
                                  'top': check_is_NaN, 'type': 'NUM', 'variance': 561.125}
         expected_results['y'] = {'25%': 10.125000249999999, '5%': -2.0420348747749997, '50%': 15.942256,
-                                 '75%': 246.78800000000001, '95%': 2258.2531999999987, 'count': 8,
+                                 '75%': 246.78800000000001, '95%': 2258.2531999999987, 'count': 8, 'n_infinite': 0, 'p_infinite': 0,
                                  'cv': 2.2112992878833846, 'distinct_count': 9, 'freq': check_is_NaN,
                                  'iqr': 236.66299975000001, 'is_unique': True, 'kurtosis': 6.974137018717359,
                                  'mad': 698.45081747834365, 'max': 3122.0, 'mean': 491.17436504331249,
@@ -67,21 +67,21 @@ class DataFrameTest(unittest.TestCase):
                                  'range': 3125.1415926535001, 'skewness': 2.6156591135729266, 'std': 1086.1335236468506,
                                  'sum': 3929.3949203464999, 'top': check_is_NaN, 'type': 'NUM',
                                  'variance': 1179686.0311895239}
-        expected_results['cat'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 8,
+        expected_results['cat'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 8, 'n_infinite': 0, 'p_infinite': 0,
                                    'cv': check_is_NaN, 'distinct_count': 7, 'freq': 3, 'histogram': check_is_NaN, 'iqr': check_is_NaN,
                                    'is_unique': False, 'kurtosis': check_is_NaN, 'mad': check_is_NaN, 'max': check_is_NaN, 'mean': check_is_NaN,
                                    'min': check_is_NaN, 'mini_histogram': check_is_NaN, 'mode': 'c',
                                    'n_missing': 1, 'p_missing': 0.11111111111111116, 'p_unique': 0.875,
                                    'p_zeros': check_is_NaN, 'range': check_is_NaN, 'skewness': check_is_NaN, 'std': check_is_NaN, 'sum': check_is_NaN,
                                    'top': 'c', 'type': 'CAT', 'variance': check_is_NaN}
-        expected_results['s1'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 9,
+        expected_results['s1'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 9, 'n_infinite': 0, 'p_infinite': 0,
                                   'cv': check_is_NaN, 'distinct_count': 1, 'freq': check_is_NaN, 'histogram': check_is_NaN, 'iqr': check_is_NaN,
                                   'is_unique': False, 'kurtosis': check_is_NaN, 'mad': check_is_NaN, 'max': check_is_NaN, 'mean': check_is_NaN,
                                   'min': check_is_NaN, 'mini_histogram': check_is_NaN, 'mode': 1.0,
                                   'n_missing': 0, 'p_missing': 0.0, 'p_unique': 0.1111111111111111, 'p_zeros': check_is_NaN,
                                   'range': check_is_NaN, 'skewness': check_is_NaN, 'std': check_is_NaN, 'sum': check_is_NaN, 'top': check_is_NaN,
                                   'type': 'CONST', 'variance': check_is_NaN}
-        expected_results['s2'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 9,
+        expected_results['s2'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 9, 'n_infinite': 0, 'p_infinite': 0,
                                   'cv': check_is_NaN, 'distinct_count': 1, 'freq': check_is_NaN, 'histogram': check_is_NaN, 'iqr': check_is_NaN,
                                   'is_unique': False, 'kurtosis': check_is_NaN, 'mad': check_is_NaN, 'max': check_is_NaN, 'mean': check_is_NaN,
                                   'min': check_is_NaN, 'mini_histogram': check_is_NaN,
@@ -90,7 +90,7 @@ class DataFrameTest(unittest.TestCase):
                                   'skewness': check_is_NaN, 'std': check_is_NaN, 'sum': check_is_NaN, 'top': check_is_NaN, 'type': 'CONST',
                                   'variance': check_is_NaN}
         expected_results['somedate'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN,
-                                        'count': 8, 'cv': check_is_NaN, 'distinct_count': 6, 'freq': check_is_NaN,
+                                        'count': 8, 'n_infinite': 0, 'p_infinite': 0, 'cv': check_is_NaN, 'distinct_count': 6, 'freq': check_is_NaN,
                                         'histogram': check_is_NaN, 'iqr': check_is_NaN, 'is_unique': False, 'kurtosis': check_is_NaN,
                                         'mad': check_is_NaN, 'max': datetime.datetime(2022, 1, 1, 13, 57), 'mean': check_is_NaN,
                                         'min': datetime.datetime(1898, 1, 2),


### PR DESCRIPTION
Previously, if you ran pandas_profiling on a DataFrame with numpy infinite values, you would get the error `ValueError: range parameter must be finite.` from the call to `plot = series.plot(kind='hist')` in `describe_numeric_1d()` in `base.py`. For example:

```
dates = pd.date_range('20130101',periods=6)
df = pd.DataFrame(np.random.randn(6,4),index=dates,columns=list('ABCD'))
df['A'][0] = np.inf
pandas_profiling.ProfileReport(df)
```

We now replace infinite values with NaNs:

```
data.replace(to_replace=[np.inf, np.NINF, np.PINF], value=np.nan, inplace=True)
```

and while we're at it, we alert the user to the presence of these values in the profile report.