### PR TITLE
added optional corr_threshold and display warnings toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ target/
 
 # remove pycharm boilerplate files
 .idea
+SB_PUSH_INSTRUCTIONS

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,9 @@ target/
 
 # remove pycharm boilerplate files
 .idea
+
 SB_PUSH_INSTRUCTIONS
+*.py.swp
+
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-#pandas-profiling 
-Generates profile reports from a pandas DataFrame. The *df.describe()* function is great but a little basic for serious exploratory data analysis. 
+# pandas-profiling
+Generates profile reports from a pandas DataFrame. The *df.describe()* function is great but a little basic for serious exploratory data analysis.
 
 For each column the following statistics - if relevant for the column type - are presented in an interactive HTML report:
 
@@ -27,10 +27,10 @@ Download the source code by cloning the repo or by pressing 'Download ZIP' on th
     python setup.py install
 
 ## Usage
-The profile report is written in HTML5 and CSS3, which means pandas-profiling requires a modern browser. 
+The profile report is written in HTML5 and CSS3, which means pandas-profiling requires a modern browser.
 
 ### Jupyter Notebook (formerly IPython)
-We recommend generating reports interactively by using the Jupyter notebook. 
+We recommend generating reports interactively by using the Jupyter notebook.
 
 Start by loading in your pandas DataFrame, e.g. by using
 
@@ -41,7 +41,7 @@ Start by loading in your pandas DataFrame, e.g. by using
 To display the report in a Jupyter notebook, run:
 
 	pandas_profiling.ProfileReport(df)
-	
+
 To retrieve the list of variables which are rejected due to high correlation:
 
     profile = pandas_profiling.ProfileReport(df)

--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -29,7 +29,8 @@ class ProfileReport(object):
 
         description_set = describe(df, **kwargs)
 
-        description_set['variables'].sort_values('AUC', ascending=False, inplace=True)
+        description_set['variables'].sort_values(
+            'AUC', ascending=False, inplace=True)
 
         self.html = to_html(sample,
                             description_set)
@@ -66,4 +67,3 @@ class ProfileReport(object):
 
     def __str__(self):
         return "Output written to file " + str(self.file.name)
-

--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -29,6 +29,8 @@ class ProfileReport(object):
 
         description_set = describe(df, **kwargs)
 
+        description_set['variables'].sort_values('AUC', ascending=False, inplace=True)
+
         self.html = to_html(sample,
                             description_set)
 

--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -1,7 +1,9 @@
 
 import codecs
 from .templates import wrapper_html
+from . import sb_utils
 from .base import describe, to_html
+
 
 NO_OUTPUTFILE = "pandas_profiling.no_outputfile"
 DEFAULT_OUTPUTFILE = "pandas_profiling.default_outputfile"
@@ -12,6 +14,16 @@ class ProfileReport(object):
     file = None
 
     def __init__(self, df, **kwargs):
+        """
+        Generates a object containing summary statistics for a given DataFrame
+        :param df: DataFrame to be analyzed
+        :param bins: Number of bins in histogram
+        :param corr_threshold: Correlation threshold to exclude variables
+        :return: Dictionary containing
+            table: general statistics on the DataFrame
+            variables: summary statistics for each variable
+            freq: frequency table
+        """
 
         sample = kwargs.get('sample', df.head())
 
@@ -52,6 +64,4 @@ class ProfileReport(object):
 
     def __str__(self):
         return "Output written to file " + str(self.file.name)
-
-
 

--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -30,6 +30,7 @@ def describe(df, **kwargs):
     Generates a object containing summary statistics for a given DataFrame
     :param df: DataFrame to be analyzed
     :param bins: Number of bins in histogram
+    :param corr_threshold: Correlation threshold to exclude variables
     :return: Dictionary containing
         table: general statistics on the DataFrame
         variables: summary statistics for each variable
@@ -42,6 +43,7 @@ def describe(df, **kwargs):
         raise ValueError("df can not be empty")
 
     bins = kwargs.get('bins', 10)
+    corr_threshold = kwargs.get('corr_threshold', 0.9)
 
     try:
         # reset matplotlib style before use
@@ -148,7 +150,7 @@ def describe(df, **kwargs):
         data.replace(to_replace=[np.inf, np.NINF, np.PINF], value=np.nan, inplace=True)
 
         n_infinite = count - data.count()  # number of infinte observations in the Series
-        
+
         distinct_count = data.nunique(dropna=False)  # number of unique elements in the Series
         if count > distinct_count > 1:
             mode = data.mode().iloc[0]
@@ -201,7 +203,7 @@ def describe(df, **kwargs):
         for y, corr in corr_x.iteritems():
             if x == y: break
 
-            if corr > 0.9:
+            if corr > corr_threshold:
                 ldesc[x] = pd.Series(['CORR', y, corr], index=['type', 'correlation_var', 'correlation'], name=x)
 
     # Convert ldesc to a DataFrame

--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -13,12 +13,13 @@ except ImportError:
 import base64
 
 import matplotlib
-#matplotlib.use('Agg')
+# matplotlib.use('Agg')
 
 import numpy as np
 import os
 import pandas as pd
-import pandas_profiling.formatters as formatters, pandas_profiling.templates as templates
+import pandas_profiling.formatters as formatters
+import pandas_profiling.templates as templates
 from matplotlib import pyplot as plt
 from pandas.core import common as com
 import six
@@ -30,6 +31,7 @@ from IPython.core.debugger import Tracer
 import seaborn as sns
 sns.set_style('dark')
 sns.set_context('notebook')
+
 
 def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
     """
@@ -74,8 +76,8 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
 
     def describe_numeric_1d(series, base_stats):
         stats = {'mean': series.mean(), 'std': series.std(),
-                'variance': series.var(), 'min': series.min(),
-                'max': series.max()}
+                 'variance': series.var(), 'min': series.min(),
+                 'max': series.max()}
         stats['range'] = stats['max'] - stats['min']
 
         for x in np.array([0.05, 0.25, 0.5, 0.75, 0.95]):
@@ -99,8 +101,10 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
             #plot.figure.subplots_adjust(left=0.15, right=0.95, top=0.9, bottom=0.1, wspace=0, hspace=0)
             plot.figure.savefig(imgdata)
             imgdata.seek(0)
-            stats['histogram'] = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
-            #TODO Think about writing this to disk instead of caching them in strings
+            stats['histogram'] = 'data:image/png;base64,' + \
+                quote(base64.b64encode(imgdata.getvalue()))
+            # TODO Think about writing this to disk instead of caching them in
+            # strings
             plt.close(plot.figure)
 
         stats['mini_histogram'] = mini_histogram(series)
@@ -119,7 +123,8 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
     def mini_histogram(series):
         # Small histogram
         imgdata = BytesIO()
-        plot = series.plot(kind='hist', figsize=(2, 0.75), facecolor='#337ab7', bins=bins)
+        plot = series.plot(kind='hist', figsize=(2, 0.75),
+                           facecolor='#337ab7', bins=bins)
         plot.axes.get_yaxis().set_visible(False)
         plot.set_axis_bgcolor("w")
         xticks = plot.xaxis.get_major_ticks()
@@ -128,10 +133,12 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
             tick.label.set_visible(False)
         for tick in (xticks[0], xticks[-1]):
             tick.label.set_fontsize(8)
-        plot.figure.subplots_adjust(left=0.15, right=0.85, top=1, bottom=0.35, wspace=0, hspace=0)
+        plot.figure.subplots_adjust(
+            left=0.15, right=0.85, top=1, bottom=0.35, wspace=0, hspace=0)
         plot.figure.savefig(imgdata)
         imgdata.seek(0)
-        result_string = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+        result_string = 'data:image/png;base64,' + \
+            quote(base64.b64encode(imgdata.getvalue()))
         plt.close(plot.figure)
         return result_string
 
@@ -181,11 +188,13 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
 
         # Replace infinite values with NaNs to avoid issues with
         # histograms later.
-        data.replace(to_replace=[np.inf, np.NINF, np.PINF], value=np.nan, inplace=True)
+        data.replace(to_replace=[np.inf, np.NINF,
+                                 np.PINF], value=np.nan, inplace=True)
 
         n_infinite = count - data.count()  # number of infinte observations in the Series
 
-        distinct_count = data.nunique(dropna=False)  # number of unique elements in the Series
+        # number of unique elements in the Series
+        distinct_count = data.nunique(dropna=False)
         if count > distinct_count > 1:
             mode = data.mode().iloc[0]
         else:
@@ -237,10 +246,12 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
     corr = df.corr()
     for x, corr_x in corr.iterrows():
         for y, corr in corr_x.iteritems():
-            if x == y: break
+            if x == y:
+                break
 
             if corr > corr_threshold:
-                ldesc[x] = pd.Series(['CORR', y, corr], index=['type', 'correlation_var', 'correlation'], name=x)
+                ldesc[x] = pd.Series(['CORR', y, corr], index=[
+                                     'type', 'correlation_var', 'correlation'], name=x)
 
     # Convert ldesc to a DataFrame
     names = []
@@ -255,14 +266,17 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
 
     # General statistics
     table_stats = {'n': len(df), 'nvar': len(df.columns)}
-    table_stats['total_missing'] = variable_stats.loc['n_missing'].sum() / (table_stats['n'] * table_stats['nvar'])
+    table_stats['total_missing'] = variable_stats.loc[
+        'n_missing'].sum() / (table_stats['n'] * table_stats['nvar'])
     table_stats['n_duplicates'] = sum(df.duplicated())
 
     memsize = df.memory_usage(index=True).sum()
     table_stats['memsize'] = formatters.fmt_bytesize(memsize)
-    table_stats['recordsize'] = formatters.fmt_bytesize(memsize / table_stats['n'])
+    table_stats['recordsize'] = formatters.fmt_bytesize(
+        memsize / table_stats['n'])
 
-    table_stats.update({k: 0 for k in ("NUM", "DATE", "CONST", "CAT", "UNIQUE", "CORR")})
+    table_stats.update(
+        {k: 0 for k in ("NUM", "DATE", "CONST", "CAT", "UNIQUE", "CORR")})
     table_stats.update(dict(variable_stats.loc['type'].value_counts()))
     table_stats['REJECTED'] = table_stats['CONST'] + table_stats['CORR']
 
@@ -270,7 +284,6 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
 
 
 def to_html(sample, stats_object):
-
     """
     Generate a HTML report from summary statistics and a given sample
     :param sample: DataFrame containing the sample you want to print
@@ -287,10 +300,12 @@ def to_html(sample, stats_object):
         raise TypeError("sample must be of type pandas.DataFrame")
 
     if not isinstance(stats_object, dict):
-        raise TypeError("stats_object must be of type dict. Did you generate this using the pandas_profiling.describe() function?")
+        raise TypeError(
+            "stats_object must be of type dict. Did you generate this using the pandas_profiling.describe() function?")
 
     if set(stats_object.keys()) != {'table', 'variables', 'freq'}:
-        raise TypeError("stats_object badly formatted. Did you generate this using the pandas_profiling-eda.describe() function?")
+        raise TypeError(
+            "stats_object badly formatted. Did you generate this using the pandas_profiling-eda.describe() function?")
 
     def fmt(value, name):
         if pd.isnull(value):
@@ -328,7 +343,8 @@ def to_html(sample, stats_object):
             return row_template.format(label=label,
                                        width=width,
                                        count=freq,
-                                       percentage='{:2.1f}'.format(freq / n * 100),
+                                       percentage='{:2.1f}'.format(
+                                           freq / n * 100),
                                        extra_class=extra_class,
                                        label_in_bar=label_in_bar,
                                        label_after_bar=label_after_bar)
@@ -338,11 +354,13 @@ def to_html(sample, stats_object):
 
         if freq_other > min_freq:
             freq_rows_html += format_row(freq_other,
-                                         "Other values (%s)" % (freqtable.count() - max_number_of_items_in_table),
+                                         "Other values (%s)" % (
+                                             freqtable.count() - max_number_of_items_in_table),
                                          extra_class='other')
 
         if freq_missing > min_freq:
-            freq_rows_html += format_row(freq_missing, "(Missing)", extra_class='missing')
+            freq_rows_html += format_row(freq_missing,
+                                         "(Missing)", extra_class='missing')
 
         return table_template.format(rows=freq_rows_html, varid=hash(idx))
 
@@ -361,7 +379,8 @@ def to_html(sample, stats_object):
         for col in set(row.index) & six.viewkeys(row_formatters):
             row_classes[col] = row_formatters[col](row[col])
             if row_classes[col] == "alert" and col in templates.messages:
-                messages.append(templates.messages[col].format(formatted_values, varname = formatters.fmt_varname(idx)))
+                messages.append(templates.messages[col].format(
+                    formatted_values, varname=formatters.fmt_varname(idx)))
 
         if row['type'] == 'CAT':
             formatted_values['minifreqtable'] = freq_table(stats_object['freq'][idx], n_obs,
@@ -369,7 +388,8 @@ def to_html(sample, stats_object):
             formatted_values['freqtable'] = freq_table(stats_object['freq'][idx], n_obs,
                                                        templates.freq_table, templates.freq_table_row, 20)
             if row['distinct_count'] > 50:
-                messages.append(templates.messages['HIGH_CARDINALITY'].format(formatted_values, varname = formatters.fmt_varname(idx)))
+                messages.append(templates.messages['HIGH_CARDINALITY'].format(
+                    formatted_values, varname=formatters.fmt_varname(idx)))
                 row_classes['distinct_count'] = "alert"
             else:
                 row_classes['distinct_count'] = ""
@@ -377,43 +397,53 @@ def to_html(sample, stats_object):
         if row['type'] == 'UNIQUE':
             obs = stats_object['freq'][idx].index
 
-            formatted_values['firstn'] = pd.DataFrame(obs[0:3], columns=["First 3 values"]).to_html(classes="example_values", index=False)
-            formatted_values['lastn'] = pd.DataFrame(obs[-3:], columns=["Last 3 values"]).to_html(classes="example_values", index=False)
+            formatted_values['firstn'] = pd.DataFrame(
+                obs[0:3], columns=["First 3 values"]).to_html(classes="example_values", index=False)
+            formatted_values['lastn'] = pd.DataFrame(
+                obs[-3:], columns=["Last 3 values"]).to_html(classes="example_values", index=False)
 
             if n_obs > 40:
-                formatted_values['firstn_expanded'] = pd.DataFrame(obs[0:20], index=range(1, 21)).to_html(classes="sample table table-hover", header=False)
-                formatted_values['lastn_expanded'] = pd.DataFrame(obs[-20:], index=range(n_obs - 20 + 1, n_obs+1)).to_html(classes="sample table table-hover", header=False)
+                formatted_values['firstn_expanded'] = pd.DataFrame(obs[0:20], index=range(
+                    1, 21)).to_html(classes="sample table table-hover", header=False)
+                formatted_values['lastn_expanded'] = pd.DataFrame(obs[-20:], index=range(
+                    n_obs - 20 + 1, n_obs + 1)).to_html(classes="sample table table-hover", header=False)
             else:
-                formatted_values['firstn_expanded'] = pd.DataFrame(obs, index=range(1, n_obs+1)).to_html(classes="sample table table-hover", header=False)
+                formatted_values['firstn_expanded'] = pd.DataFrame(obs, index=range(
+                    1, n_obs + 1)).to_html(classes="sample table table-hover", header=False)
                 formatted_values['lastn_expanded'] = ''
 
         try:
-            rows_html += templates.row_templates_dict[row['type']].format(formatted_values, row_classes=row_classes)
+            rows_html += templates.row_templates_dict[row['type']].format(
+                formatted_values, row_classes=row_classes)
         except KeyError:
             Tracer()()
 
         if row['type'] in {'CORR', 'CONST'}:
             formatted_values['varname'] = formatters.fmt_varname(idx)
-            messages.append(templates.messages[row['type']].format(formatted_values))
-
+            messages.append(templates.messages[
+                            row['type']].format(formatted_values))
 
     # Overview
-    formatted_values = {k: fmt(v, k) for k, v in six.iteritems(stats_object['table'])}
+    formatted_values = {k: fmt(v, k)
+                        for k, v in six.iteritems(stats_object['table'])}
 
-    row_classes={}
+    row_classes = {}
     for col in six.viewkeys(stats_object['table']) & six.viewkeys(row_formatters):
         row_classes[col] = row_formatters[col](stats_object['table'][col])
         if row_classes[col] == "alert" and col in templates.messages:
-            messages.append(templates.messages[col].format(formatted_values, varname = formatters.fmt_varname(idx)))
+            messages.append(templates.messages[col].format(
+                formatted_values, varname=formatters.fmt_varname(idx)))
 
     messages_html = u''
     for msg in messages:
         messages_html += templates.message_row.format(message=msg)
 
-    overview_html = templates.overview_template.format(formatted_values, row_classes = row_classes, messages=messages_html)
+    overview_html = templates.overview_template.format(
+        formatted_values, row_classes=row_classes, messages=messages_html)
 
     # Sample
 
-    sample_html = templates.sample_html.format(sample_table_html=sample.to_html(classes="sample"))
+    sample_html = templates.sample_html.format(
+        sample_table_html=sample.to_html(classes="sample"))
 
     return templates.base_html % {'overview_html': overview_html, 'rows_html': rows_html, 'sample_html': sample_html}

--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -13,7 +13,6 @@ except ImportError:
 import base64
 
 import matplotlib
-matplotlib.use('Agg')
 
 import numpy as np
 import os
@@ -24,13 +23,22 @@ from pandas.core import common as com
 import six
 from pkg_resources import resource_filename
 
+from .sb_utils.sb_univar import *
 
-def describe(df, **kwargs):
+
+from IPython.core.debugger import Tracer
+import seaborn as sns
+sns.set_style('dark')
+sns.set_context('notebook')
+
+def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
     """
     Generates a object containing summary statistics for a given DataFrame
     :param df: DataFrame to be analyzed
     :param bins: Number of bins in histogram
     :param corr_threshold: Correlation threshold to exclude variables
+    :param ft_names: Dict of Column_Name: Feature Definitions
+
     :return: Dictionary containing
         table: general statistics on the DataFrame
         variables: summary statistics for each variable
@@ -42,8 +50,11 @@ def describe(df, **kwargs):
     if df.empty:
         raise ValueError("df can not be empty")
 
-    bins = kwargs.get('bins', 10)
-    corr_threshold = kwargs.get('corr_threshold', 0.9)
+    if isinstance(y, str):
+        y_name = y
+        y = df[y].copy().as_matrix()
+        df = df.copy()
+        del df[y_name]
 
     try:
         # reset matplotlib style before use
@@ -51,8 +62,6 @@ def describe(df, **kwargs):
         matplotlib.style.use("default")
     except:
         pass
-
-    matplotlib.style.use(resource_filename(__name__, "pandas_profiling.mplstyle"))
 
     def pretty_name(x):
         x *= 100
@@ -62,7 +71,8 @@ def describe(df, **kwargs):
             return '%.1f%%' % x
 
     def describe_numeric_1d(series, base_stats):
-        stats = {'mean': series.mean(), 'std': series.std(), 'variance': series.var(), 'min': series.min(),
+        stats = {'mean': series.mean(), 'std': series.std(),
+                'variance': series.var(), 'min': series.min(),
                 'max': series.max()}
         stats['range'] = stats['max'] - stats['min']
 
@@ -80,18 +90,28 @@ def describe(df, **kwargs):
 
         # Large histogram
         imgdata = BytesIO()
-        plot = series.plot(kind='hist', figsize=(6, 4),
-                           facecolor='#337ab7', bins=bins)  # TODO when running on server, send this off to a different thread
-        plot.figure.subplots_adjust(left=0.15, right=0.95, top=0.9, bottom=0.1, wspace=0, hspace=0)
-        plot.figure.savefig(imgdata)
-        imgdata.seek(0)
-        stats['histogram'] = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
-        #TODO Think about writing this to disk instead of caching them in strings
-        plt.close(plot.figure)
+        with sns.axes_style('whitegrid'):
+            plot = series.plot(kind='hist', figsize=(6, 4),
+                               facecolor='#337ab7', bins=bins)  # TODO when running on server, send this off to a different thread
+            #sns.despine(left=True, trim=True)
+            #plot.figure.subplots_adjust(left=0.15, right=0.95, top=0.9, bottom=0.1, wspace=0, hspace=0)
+            plot.figure.savefig(imgdata)
+            imgdata.seek(0)
+            stats['histogram'] = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+            plt.close(plot.figure)
 
         stats['mini_histogram'] = mini_histogram(series)
+        series_name = series.name
 
-        return pd.Series(stats, name=series.name)
+        if y is not None:
+            mdld = mdl_1d(series, y)
+            stats['AUC'] = mdld[0]
+            stats['cmatrix'] = mdld[1]
+        else:
+            stats['AUC'] = 'No Dep Var'
+            stats['cmatrix'] = ''
+
+        return pd.Series(stats, name=series_name)
 
     def mini_histogram(series):
         # Small histogram
@@ -133,6 +153,17 @@ def describe(df, **kwargs):
             names += ['top', 'freq', 'type']
             result += [top, freq, 'CAT']
 
+        if y is not None:
+            try:
+                mdld = mdl_1d(data, y)
+                result += [*mdld]
+            except:
+                Tracer()()
+        else:
+            result += ['No Dep Var', '']
+
+        names += ['AUC', 'cmatrix']
+
         return pd.Series(result, index=names, name=data.name)
 
     def describe_constant_1d(data):
@@ -165,7 +196,8 @@ def describe(df, **kwargs):
                         'n_infinite': n_infinite,
                         'is_unique': distinct_count == leng,
                         'mode': mode,
-                        'p_unique': distinct_count / count}
+                        'p_unique': distinct_count / count,
+                        'ft_dfn': ft_names.get(data.name, '')}
         try:
             # pandas 0.17 onwards
             results_data['memorysize'] = data.memory_usage()
@@ -184,6 +216,7 @@ def describe(df, **kwargs):
             result = result.append(describe_unique_1d(data))
         else:
             result = result.append(describe_categorical_1d(data))
+
         return result
 
     if not pd.Index(np.arange(0, len(df))).equals(df.index):
@@ -213,6 +246,7 @@ def describe(df, **kwargs):
         for name in idxnames:
             if name not in names:
                 names.append(name)
+
     variable_stats = pd.concat(ldesc, join_axes=pd.Index([names]), axis=1)
     variable_stats.columns.names = df.columns.names
 
@@ -350,7 +384,10 @@ def to_html(sample, stats_object):
                 formatted_values['firstn_expanded'] = pd.DataFrame(obs, index=range(1, n_obs+1)).to_html(classes="sample table table-hover", header=False)
                 formatted_values['lastn_expanded'] = ''
 
-        rows_html += templates.row_templates_dict[row['type']].format(formatted_values, row_classes=row_classes)
+        try:
+            rows_html += templates.row_templates_dict[row['type']].format(formatted_values, row_classes=row_classes)
+        except KeyError:
+            Tracer()()
 
         if row['type'] in {'CORR', 'CONST'}:
             formatted_values['varname'] = formatters.fmt_varname(idx)

--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -13,6 +13,7 @@ except ImportError:
 import base64
 
 import matplotlib
+#matplotlib.use('Agg')
 
 import numpy as np
 import os
@@ -21,7 +22,6 @@ import pandas_profiling.formatters as formatters, pandas_profiling.templates as 
 from matplotlib import pyplot as plt
 from pandas.core import common as com
 import six
-from pkg_resources import resource_filename
 
 from .sb_utils.sb_univar import *
 
@@ -63,6 +63,8 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
     except:
         pass
 
+    #matplotlib.style.use(resource_filename(__name__, "pandas_profiling.mplstyle"))
+
     def pretty_name(x):
         x *= 100
         if x == int(x):
@@ -98,6 +100,7 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
             plot.figure.savefig(imgdata)
             imgdata.seek(0)
             stats['histogram'] = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+            #TODO Think about writing this to disk instead of caching them in strings
             plt.close(plot.figure)
 
         stats['mini_histogram'] = mini_histogram(series)
@@ -156,7 +159,7 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
         if y is not None:
             try:
                 mdld = mdl_1d(data, y)
-                result += [*mdld]
+                result += list(mdld)
             except:
                 Tracer()()
         else:

--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -165,7 +165,7 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
 
         if y is not None:
             try:
-                mdld = mdl_1d(data, y)
+                mdld = mdl_1d_cat(data, y)
                 result += list(mdld)
             except:
                 Tracer()()

--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -33,13 +33,14 @@ sns.set_style('dark')
 sns.set_context('notebook')
 
 
-def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
+def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}, to_numeric=1):
     """
     Generates a object containing summary statistics for a given DataFrame
     :param df: DataFrame to be analyzed
     :param bins: Number of bins in histogram
     :param corr_threshold: Correlation threshold to exclude variables
     :param ft_names: Dict of Column_Name: Feature Definitions
+    :param to_numeric: 1 to convert numbers stored as objects to float
 
     :return: Dictionary containing
         table: general statistics on the DataFrame
@@ -64,6 +65,19 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
         matplotlib.style.use("default")
     except:
         pass
+
+
+    #auto parse date columns
+    df = df.apply(lambda col: pd.to_datetime(col, errors='ignore') 
+              if col.dtypes == object 
+              else col, 
+              axis=0)
+
+    #auto parse numeric columns stored as object to float
+    df = df.apply(lambda col: pd.to_numeric(col, errors='ignore') 
+              if col.dtypes == object 
+              else col, 
+              axis=0)
 
     #matplotlib.style.use(resource_filename(__name__, "pandas_profiling.mplstyle"))
 
@@ -114,9 +128,11 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}):
             mdld = mdl_1d(series, y)
             stats['AUC'] = mdld[0]
             stats['cmatrix'] = mdld[1]
+            stats['bplot'] = mdld[2]
         else:
             stats['AUC'] = 'No Dep Var'
             stats['cmatrix'] = ''
+            stats['bplot'] = ''
 
         return pd.Series(stats, name=series_name)
 

--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -66,18 +66,17 @@ def describe(df, y=None, bins=10, corr_threshold=0.9, ft_names={}, to_numeric=1)
     except:
         pass
 
+    # auto parse date columns
+    df = df.apply(lambda col: pd.to_datetime(col, errors='ignore')
+                  if col.dtypes == object
+                  else col,
+                  axis=0)
 
-    #auto parse date columns
-    df = df.apply(lambda col: pd.to_datetime(col, errors='ignore') 
-              if col.dtypes == object 
-              else col, 
-              axis=0)
-
-    #auto parse numeric columns stored as object to float
-    df = df.apply(lambda col: pd.to_numeric(col, errors='ignore') 
-              if col.dtypes == object 
-              else col, 
-              axis=0)
+    # auto parse numeric columns stored as object to float
+    df = df.apply(lambda col: pd.to_numeric(col, errors='ignore')
+                  if col.dtypes == object
+                  else col,
+                  axis=0)
 
     #matplotlib.style.use(resource_filename(__name__, "pandas_profiling.mplstyle"))
 

--- a/pandas_profiling/formatters.py
+++ b/pandas_profiling/formatters.py
@@ -8,22 +8,22 @@ DEFAULT_FLOAT_FORMATTER = u'pandas_profiling.__default_float_formatter'
 
 
 def gradient_format(value, limit1, limit2, c1, c2):
-    def LerpColour(c1,c2,t):
-        return (int(c1[0]+(c2[0]-c1[0])*t),int(c1[1]+(c2[1]-c1[1])*t),int(c1[2]+(c2[2]-c1[2])*t))
-    c = LerpColour(c1, c2, (value-limit1)/(limit2-limit1))
-    return fmt_color(value,"rgb{}".format(str(c)))
+    def LerpColour(c1, c2, t):
+        return (int(c1[0] + (c2[0] - c1[0]) * t), int(c1[1] + (c2[1] - c1[1]) * t), int(c1[2] + (c2[2] - c1[2]) * t))
+    c = LerpColour(c1, c2, (value - limit1) / (limit2 - limit1))
+    return fmt_color(value, "rgb{}".format(str(c)))
 
 
 def fmt_color(text, color):
-    return(u'<span style="color:{color}">{text}</span>'.format(color=color,text=str(text)))
+    return(u'<span style="color:{color}">{text}</span>'.format(color=color, text=str(text)))
 
 
 def fmt_class(text, cls):
-    return(u'<span class="{cls}">{text}</span>'.format(cls=cls,text=str(text)))
+    return(u'<span class="{cls}">{text}</span>'.format(cls=cls, text=str(text)))
 
 
 def fmt_bytesize(num, suffix='B'):
-    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
         if abs(num) < 1024.0:
             return "%3.1f %s%s" % (num, unit, suffix)
         num /= 1024.0
@@ -31,37 +31,40 @@ def fmt_bytesize(num, suffix='B'):
 
 
 def fmt_percent(v):
-    return  "{:2.1f}%".format(v*100)
+    return "{:2.1f}%".format(v * 100)
+
 
 def fmt_varname(v):
     return u'<code>{0}</code>'.format(v)
 
 
-value_formatters={
-        u'freq': (lambda v: gradient_format(v, 0, 62000, (30, 198, 244), (99, 200, 72))),
-        u'p_missing': fmt_percent,
-        u'p_infinite': fmt_percent,
-        u'p_unique': fmt_percent,
-        u'p_zeros': fmt_percent,
-        u'memorysize': fmt_bytesize,
-        u'total_missing': fmt_percent,
-        DEFAULT_FLOAT_FORMATTER: lambda v: str(float('{:.5g}'.format(v))).rstrip('0').rstrip('.'),
-        u'correlation_var': lambda v: fmt_varname(v),
-        }
+value_formatters = {
+    u'freq': (lambda v: gradient_format(v, 0, 62000, (30, 198, 244), (99, 200, 72))),
+    u'p_missing': fmt_percent,
+    u'p_infinite': fmt_percent,
+    u'p_unique': fmt_percent,
+    u'p_zeros': fmt_percent,
+    u'memorysize': fmt_bytesize,
+    u'total_missing': fmt_percent,
+    DEFAULT_FLOAT_FORMATTER: lambda v: str(float('{:.5g}'.format(v))).rstrip('0').rstrip('.'),
+    u'correlation_var': lambda v: fmt_varname(v),
+}
+
 
 def fmt_row_severity(v):
-    if np.isnan(v) or v<= 0.01:
+    if np.isnan(v) or v <= 0.01:
         return "ignore"
     else:
         return "alert"
 
+
 def fmt_skewness(v):
-    if not np.isnan(v) and (v<-SKEWNESS_CUTOFF or v> SKEWNESS_CUTOFF):
+    if not np.isnan(v) and (v < -SKEWNESS_CUTOFF or v > SKEWNESS_CUTOFF):
         return "alert"
     else:
         return ""
 
-row_formatters={
+row_formatters = {
     u'p_zeros': fmt_row_severity,
     u'p_missing': fmt_row_severity,
     u'p_infinite': fmt_row_severity,

--- a/pandas_profiling/sb_hide_ignored.js
+++ b/pandas_profiling/sb_hide_ignored.js
@@ -1,0 +1,91 @@
+/*function sb_toggle_viz(){
+	var ignore_vars = document.getElementsByClassName('row variablerow ignore')
+
+	for(var i = 0; i < ignore_vars.length; i++)
+		{
+		ignore_vars[i].style.visibility="hidden";
+		}
+}
+*/
+//<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+
+function sb_hide(){
+    ignore_vars = $('div.ignore');
+
+    cur_status = ignore_vars[0].style['display'];
+
+    if (cur_status == 'none') {
+            ignore_vars.show()
+    } else {
+            ignore_vars.hide()
+    };
+};
+
+
+<script>
+    document.getElementById('warnButton').onclick = function() {
+            sb_hide();
+    };
+</script>
+
+
+// finds specific p.h4 with text == varname
+function findVarDiv(varname){
+    var_p = $("p.h4").filter(function(index) { return this.textContent.match(varname)});
+    return var_p.parent()[0];
+}
+
+// then, use findVarDiv(id).scrollIntoView(); to jump to
+function jumpToVar(div_id){
+    div_id.scrollIntoView()
+}
+
+// hahah fuck all taht noise
+function buildDropdown(){
+    //var all_vars = $('div.variablerow').map(function(index, dom) {return dom.id});
+	//all_vars = $(all_vars).filter(function(index, val) {return val.length != 0})
+    var s = $('<select />');
+
+    var div_add_to = $('div.highlight').filter(function(index) { return this.textContent.match('Variables')});
+
+    function appender(index, val){
+        $('<option />', {value: val, text: val.replace('varid_', ''}).appendTo(s);
+        };
+
+    //$(all_vars).each(appender)
+
+    $('div.variablerow').each(
+        function(idx, val)
+        {
+        if (val.style['display'] != 'none')
+            {
+            if (val.id.length != 0)
+                {
+                appender(idx, val.id)
+                }
+            }
+        }
+    )
+
+    s.appendTo($(div_add_to))
+
+	s.change(function (v) {$('#'+v.target.value).get(0).scrollIntoView()})
+}
+
+function rebuildDropdown(){
+    s = $('select')
+    s.empty()
+
+    $('div.variablerow').each(
+        function(idx, val)
+        {
+        if (val.style['display'] != 'none')
+            {
+            if (val.id.length != 0)
+                {
+                appender(idx, val.id)
+                }
+            }
+        }
+    )
+}

--- a/pandas_profiling/sb_utils/__init__.py
+++ b/pandas_profiling/sb_utils/__init__.py
@@ -1,0 +1,1 @@
+from . import sb_univar

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -236,7 +236,8 @@ def num_bin_stats(var, target, buckets=10, target_type='binary'):
     else:
         granular = 0
         cutpoints['bin'] = list(temp['var'].unique())
-        cutpoints['bin'].loc[cutpoints['bin'].isnull()] = -9999
+        tmp_min = cutpoints.ix[~cutpoints.bin.isnull(), 'bin'].min()
+        cutpoints['bin'].loc[cutpoints['bin'].isnull()] = np.minimum(-9999, tmp_min - 1000)
         try:
             cutpoints.sort_values(by='bin', inplace=True)
             cutpoints.reset_index(drop=True, inplace=True)

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -65,14 +65,14 @@ def mdl_1d(x, y):
     except ValueError:
         Tracer()()
 
-    #try:
+    # try:
     #    cm = confusion_matrix(y, (preds > y.mean()).astype(int))
-    #except ValueError:
+    # except ValueError:
     #    Tracer()()
 
     aucz = roc_auc_score(y, preds)
 
-    ns = num_bin_stats(x,y)
+    ns = num_bin_stats(x, y)
 
     nplot = plot_num(ns)
     #plot = plot_confusion_matrix(cm, y)
@@ -80,30 +80,32 @@ def mdl_1d(x, y):
     imgdata = BytesIO()
     nplot.savefig(imgdata)
     imgdata.seek(0)
-    nplot = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+    nplot = 'data:image/png;base64,' + \
+        quote(base64.b64encode(imgdata.getvalue()))
     plt.close()
 
     bplot = plot_bubble(ns)
     imgdatab = BytesIO()
     bplot.savefig(imgdatab)
     imgdatab.seek(0)
-    bplot = 'data:image/png;base64,' + quote(base64.b64encode(imgdatab.getvalue()))
+    bplot = 'data:image/png;base64,' + \
+        quote(base64.b64encode(imgdatab.getvalue()))
     plt.close()
 
     return aucz, nplot, bplot
 
 
 def plot_num(numstats):
-    fign = plt.figure(figsize=(9,6))
+    fign = plt.figure(figsize=(9, 6))
     ax1 = fign.add_subplot(111)
-    ax1.bar(numstats.index,numstats['Count'],.5,color='b',align='center')
+    ax1.bar(numstats.index, numstats['Count'], .5, color='b', align='center')
     ax2 = ax1.twinx()
-    ax2.plot(numstats.index,numstats['Target_Rate'],'-r',linewidth=4)
+    ax2.plot(numstats.index, numstats['Target_Rate'], '-r', linewidth=4)
     plt.title("Numeric Variable Univariate View")
     ax1.set_xlabel(' bin')
     ax1.set_xticks(numstats.index)
     ax1.set_xticklabels(numstats['bin'], rotation=40, ha='right')
-    ax1.set_ylabel('Number of Observations',color='b')
+    ax1.set_ylabel('Number of Observations', color='b')
     ax2.set_ylabel('Target Rate', color='r')
     for t1 in ax1.get_yticklabels():
         t1.set_color('b')
@@ -113,140 +115,156 @@ def plot_num(numstats):
 
 
 def plot_bubble(numstats):
-    bubbles = numstats.loc[((numstats['bin'].apply(lambda x: str(x))!='MISS')&(numstats['bin'].apply(lambda x: str(x))!='ZERO'))].copy()
-    bubbles['bubsize']=bubbles['Count'].apply(lambda x: int((x/np.mean(bubbles['Count']))*200))
-    figb = plt.figure(figsize=(9,6))
-    plt.scatter(x=bubbles['Mean'],y=bubbles['Target_Rate'],s=bubbles['bubsize'],c='b',label='Pop Size')
+    bubbles = numstats.loc[((numstats['bin'].apply(lambda x: str(x)) != 'MISS') & (
+        numstats['bin'].apply(lambda x: str(x)) != 'ZERO'))].copy()
+    bubbles['bubsize'] = bubbles['Count'].apply(
+        lambda x: int((x / np.mean(bubbles['Count'])) * 200))
+    figb = plt.figure(figsize=(9, 6))
+    plt.scatter(x=bubbles['Mean'], y=bubbles['Target_Rate'],
+                s=bubbles['bubsize'], c='b', label='Pop Size')
     plt.hold(True)
-    plt.plot(bubbles['Mean'],bubbles['Target_Rate'],'-r',linewidth=4,label='Target Rate')
+    plt.plot(bubbles['Mean'], bubbles['Target_Rate'],
+             '-r', linewidth=4, label='Target Rate')
     plt.title("Relational Bubble Plot")
     plt.xlabel('Mean Variable')
-    plt.ylabel('Target Rate',color='r')
+    plt.ylabel('Target Rate', color='r')
     plt.legend()
     return figb
 
 
-def num_bucket_assign(data,var,bins):
+def num_bucket_assign(data, var, bins):
 
-    #find all unique values (Non-Missing) and sort in ascending sequence
+    # find all unique values (Non-Missing) and sort in ascending sequence
     temp = data[[var]].loc[data[var].notnull()]
 
     try:
-        temp['qcut_bins'] = pd.qcut(temp[var],10)
+        temp['qcut_bins'] = pd.qcut(temp[var], 10)
 
         v = temp['qcut_bins'].unique()
 
-        #create data frame to include bin thresholds
-        b = pd.DataFrame(index=range(0,len(v)),columns=['bin'])
+        # create data frame to include bin thresholds
+        b = pd.DataFrame(index=range(0, len(v)), columns=['bin'])
 
-        for i in range(0,len(v)):
-            b['bin'].iloc[i]=(min(temp[var].loc[temp['qcut_bins']==v[i]]),
-                              max(temp[var].loc[temp['qcut_bins']==v[i]]))
+        for i in range(0, len(v)):
+            b['bin'].iloc[i] = (min(temp[var].loc[temp['qcut_bins'] == v[i]]),
+                                max(temp[var].loc[temp['qcut_bins'] == v[i]]))
 
-        bin_cuts=b.sort_values(by='bin').reset_index(drop=True)
-        #print "           - qucut worked"
+        bin_cuts = b.sort_values(by='bin').reset_index(drop=True)
+        # print "           - qucut worked"
 
     except:
-        #print "           - qucut failed"
+        # print "           - qucut failed"
         u = temp[var].unique()
 
         u.sort()
 
-        #create data frame to include unique values, counts, and assigned buckets
-        uni = pd.DataFrame(index=range(0,len(u)),columns=['value','count','bucket'])
+        # create data frame to include unique values, counts, and assigned
+        # buckets
+        uni = pd.DataFrame(index=range(0, len(u)), columns=[
+                           'value', 'count', 'bucket'])
 
-        #determine witdh of bucket based on number of obs
-        width = len(temp)/bins
+        # determine witdh of bucket based on number of obs
+        width = len(temp) / bins
 
-        #initialize current bucket and bucket size count for loop
-        csize=0
-        bucket=0
+        # initialize current bucket and bucket size count for loop
+        csize = 0
+        bucket = 0
 
-        for i in range(0,len(u)):
-            #get unique value and count
-            uni['value'].iloc[i]=u[i]
-            uni['count'].iloc[i]=len(temp.loc[temp[var] == u[i]])
+        for i in range(0, len(u)):
+            # get unique value and count
+            uni['value'].iloc[i] = u[i]
+            uni['count'].iloc[i] = len(temp.loc[temp[var] == u[i]])
 
-            #update size for current bucket and assign bucket value
-            csize=csize+uni['count'].iloc[i]
-            uni['bucket'].iloc[i]=bucket
+            # update size for current bucket and assign bucket value
+            csize = csize + uni['count'].iloc[i]
+            uni['bucket'].iloc[i] = bucket
 
-            #if current bucket size has exceeded the desired width, then start next bucket
-            if csize>=width:
-                csize=0
-                bucket=bucket+1
+            # if current bucket size has exceeded the desired width, then start
+            # next bucket
+            if csize >= width:
+                csize = 0
+                bucket = bucket + 1
 
-        #merge small last bins into previous bin
-        if (np.sum(uni['count'][uni.bucket==max(uni['bucket'])])<(width/3)):
-            uni['bucket'].loc[uni['bucket']==max(uni['bucket'])]=max(uni['bucket'])-1
+        # merge small last bins into previous bin
+        if (np.sum(uni['count'][uni.bucket == max(uni['bucket'])]) < (width / 3)):
+            uni['bucket'].loc[uni['bucket'] == max(
+                uni['bucket'])] = max(uni['bucket']) - 1
 
-        #create data frame to include bin thresholds
-        bin_cuts = pd.DataFrame(index=range(0,max(uni['bucket'])+1),columns=['bin'])
+        # create data frame to include bin thresholds
+        bin_cuts = pd.DataFrame(index=range(
+            0, max(uni['bucket']) + 1), columns=['bin'])
 
-        #assign min an max bucket values
-        for i in range(0,max(uni['bucket'])+1):
-            bin_cuts['bin'].iloc[i]=(min(uni.loc[uni['bucket']==i,'value']),max(uni.loc[uni['bucket']==i,'value']))
+        # assign min an max bucket values
+        for i in range(0, max(uni['bucket']) + 1):
+            bin_cuts['bin'].iloc[i] = (min(uni.loc[uni['bucket'] == i, 'value']), max(
+                uni.loc[uni['bucket'] == i, 'value']))
 
-    #add bucket if missing values exist
-    if sum(pd.isnull(data[var]))>0:
+    # add bucket if missing values exist
+    if sum(pd.isnull(data[var])) > 0:
         bin_cuts.loc[len(bin_cuts)] = 'MISS'
 
-    #add bucket if more than 1% of non missing values are =0
-    if (len(temp[var].loc[temp[var]==0])/float(len(temp)))>.01:
+    # add bucket if more than 1% of non missing values are =0
+    if (len(temp[var].loc[temp[var] == 0]) / float(len(temp))) > .01:
         bin_cuts.loc[len(bin_cuts)] = 'ZERO'
 
     return bin_cuts
 
 
-def num_bin_stats(var,target,buckets=10,target_type='binary'):
+def num_bin_stats(var, target, buckets=10, target_type='binary'):
 
-    #create a temporary series to work with
+    # create a temporary series to work with
     temp = pd.DataFrame()
-    temp['var']=var
-    temp['target']=target
+    temp['var'] = var
+    temp['target'] = target
 
-    #create summary dataframe for output
+    # create summary dataframe for output
     if target_type == 'binary':
-        cutpoints = pd.DataFrame(columns=('bin','Mean','Count','N_Target','Miss_Target','Target_Rate'))
+        cutpoints = pd.DataFrame(
+            columns=('bin', 'Mean', 'Count', 'N_Target', 'Miss_Target', 'Target_Rate'))
     elif target_type == 'continuous':
-        cutpoints = pd.DataFrame(columns=('bin','Mean','Count','Miss_Target','Mean_Target'))
+        cutpoints = pd.DataFrame(
+            columns=('bin', 'Mean', 'Count', 'Miss_Target', 'Mean_Target'))
     else:
-        raise TypeError("Not a Valid Target Type (needs to be 'binary' or 'continuous')")
+        raise TypeError(
+            "Not a Valid Target Type (needs to be 'binary' or 'continuous')")
 
-       #test to see if fewer levels than buckets
-    if len(temp['var'].unique())>buckets:
-        granular=1
-        cutpoints['bin'] = num_bucket_assign(temp,'var',buckets)
+       # test to see if fewer levels than buckets
+    if len(temp['var'].unique()) > buckets:
+        granular = 1
+        cutpoints['bin'] = num_bucket_assign(temp, 'var', buckets)
 
     else:
-        granular=0
+        granular = 0
         cutpoints['bin'] = list(temp['var'].unique())
-        cutpoints['bin'].loc[cutpoints['bin'].isnull()]= -9999
+        cutpoints['bin'].loc[cutpoints['bin'].isnull()] = -9999
         try:
-            cutpoints.sort_values(by='bin',inplace=True)
-            cutpoints.reset_index(drop=True,inplace=True)
+            cutpoints.sort_values(by='bin', inplace=True)
+            cutpoints.reset_index(drop=True, inplace=True)
         except Exception as e:
             print(e)
             Tracer()()
 
-    for i in range(0,len(cutpoints)):
-        if cutpoints['bin'][i]=='MISS':
+    for i in range(0, len(cutpoints)):
+        if cutpoints['bin'][i] == 'MISS':
             temp2 = temp.loc[temp['var'].isnull()]
-        elif cutpoints['bin'][i]=='ZERO':
-            temp2 = temp.loc[temp['var']==0]
+        elif cutpoints['bin'][i] == 'ZERO':
+            temp2 = temp.loc[temp['var'] == 0]
         else:
-            if granular==1:
-                temp2 = temp.loc[(temp['var']>=cutpoints['bin'].ix[i][0]) & (temp['var']<=cutpoints['bin'].ix[i][1])]
+            if granular == 1:
+                temp2 = temp.loc[(temp['var'] >= cutpoints['bin'].ix[i][0]) & (
+                    temp['var'] <= cutpoints['bin'].ix[i][1])]
             else:
-                temp2 = temp.loc[temp['var']==cutpoints['bin'][i]]
+                temp2 = temp.loc[temp['var'] == cutpoints['bin'][i]]
 
         cutpoints['Count'].iloc[i] = len(temp2)
-        cutpoints['Mean'].iloc[i] = np.mean(temp2['var'].apply(lambda x: float(x)))
+        cutpoints['Mean'].iloc[i] = np.mean(
+            temp2['var'].apply(lambda x: float(x)))
         cutpoints['Miss_Target'].iloc[i] = sum(pd.isnull(temp2['target']))
 
         if target_type == 'binary':
             cutpoints['N_Target'].iloc[i] = sum(temp2['target'])
-            cutpoints['Target_Rate'].iloc[i] = cutpoints['N_Target'].iloc[i]/(float(cutpoints['Count'].iloc[i]) + 1e-9)
+            cutpoints['Target_Rate'].iloc[i] = cutpoints['N_Target'].iloc[
+                i] / (float(cutpoints['Count'].iloc[i]) + 1e-9)
 
         if target_type == 'continuous':
             cutpoints['Mean_Target'].iloc[i] = np.mean(temp2['target'])
@@ -254,36 +272,36 @@ def num_bin_stats(var,target,buckets=10,target_type='binary'):
     return cutpoints
 
 
+def plot_cat(series, y, title="Categorical Plot", maxn=10):
+    y2 = pd.Series(y)
+    tab = pd.concat([y2.groupby(series).count(),
+                     y2.groupby(series).mean()], axis=1)
+    tab.columns = ['Count', 'Target']
+    tab.sort_values('Count', inplace=True, ascending=False)
 
-def plot_cat(series,y,title="Categorical Plot",maxn = 10):
-    y2=pd.Series(y)
-    tab = pd.concat([y2.groupby(series).count(),y2.groupby(series).mean()],axis=1)
-    tab.columns = ['Count','Target']
-    tab.sort_values('Count',inplace=True,ascending=False)
-
-    if len(tab)>maxn:
+    if len(tab) > maxn:
         short = tab[0:maxn].copy()
         short.ix['Other'] = tab[maxn:len(tab)].sum()
         tab = short.copy()
 
     tab.reset_index(inplace=True)
-    tab.columns = ['Value','Count','Target']
-    tab['Mean(y)'] = tab['Target']/tab['Count']
+    tab.columns = ['Value', 'Count', 'Target']
+    tab['Mean(y)'] = tab['Target'] / tab['Count']
     fign = plt.figure(figsize=(9, 6))
     ax1 = fign.add_subplot(111)
-    ax1.bar(tab.index,tab['Count'],.5,color='b',align='center')
+    ax1.bar(tab.index, tab['Count'], .5, color='b', align='center')
     ax2 = ax1.twinx()
-    ax2.plot(tab.index,tab['Mean(y)'],'-r',linewidth=4)
+    ax2.plot(tab.index, tab['Mean(y)'], '-r', linewidth=4)
     plt.title(title)
     ax1.set_xticks(tab.index)
     ax1.set_xticklabels(tab['Value'], rotation=40, ha='right')
-    ax1.set_ylabel('Number of Observations',color='b')
+    ax1.set_ylabel('Number of Observations', color='b')
     ax2.set_ylabel('Mean(y)', color='r')
     for t1 in ax1.get_yticklabels():
         t1.set_color('b')
     for t2 in ax2.get_yticklabels():
         t2.set_color('r')
-    #plt.tight_layout()
+    # plt.tight_layout()
     return fign
 
 
@@ -310,6 +328,7 @@ def mdl_1d_cat(x, y):
     imgdata.seek(0)
 
     aucz = roc_auc_score(y, preds)
-    cmatrix = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+    cmatrix = 'data:image/png;base64,' + \
+        quote(base64.b64encode(imgdata.getvalue()))
     plt.close()
     return aucz, cmatrix

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -236,13 +236,10 @@ def num_bin_stats(var, target, buckets=10, target_type='binary'):
     else:
         granular = 0
         cutpoints['bin'] = list(temp['var'].unique())
-        null_ixs = cutpoints['bin'].isnull()
-        tmp_min = cutpoints.bin.min()
-        cutpoints.ix[null_ixs, 'bin'] = np.minimum(-999, tmp_min)
+        cutpoints['bin'].loc[cutpoints['bin'].isnull()] = -9999
         try:
             cutpoints.sort_values(by='bin', inplace=True)
             cutpoints.reset_index(drop=True, inplace=True)
-            cutpoints.ix[null_ixs, 'bin'] = 'MISS'
         except Exception as e:
             print(e)
             Tracer()()

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -246,7 +246,7 @@ def num_bin_stats(var, target, buckets=10, target_type='binary'):
             Tracer()()
 
     for i in range(0, len(cutpoints)):
-        if cutpoints['bin'][i] == 'MISS':
+        if cutpoints['bin'][i] <= tmp_min:
             temp2 = temp.loc[temp['var'].isnull()]
         elif cutpoints['bin'][i] == 'ZERO':
             temp2 = temp.loc[temp['var'] == 0]

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -236,10 +236,13 @@ def num_bin_stats(var, target, buckets=10, target_type='binary'):
     else:
         granular = 0
         cutpoints['bin'] = list(temp['var'].unique())
-        cutpoints['bin'].loc[cutpoints['bin'].isnull()] = -9999
+        null_ixs = cutpoints['bin'].isnull()
+        tmp_min = cutpoints.bin.min()
+        cutpoints.ix[null_ixs, 'bin'] = np.minimum(-999, tmp_min)
         try:
             cutpoints.sort_values(by='bin', inplace=True)
             cutpoints.reset_index(drop=True, inplace=True)
+            cutpoints.ix[null_ixs, 'bin'] = 'MISS'
         except Exception as e:
             print(e)
             Tracer()()

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -1,0 +1,76 @@
+import pandas as pd
+import numpy as np
+
+from sklearn.linear_model import LogisticRegressionCV
+from sklearn.metrics import confusion_matrix, roc_auc_score
+from sklearn.cross_validation import train_test_split
+from pandas.core import common as com
+
+try:
+    from StringIO import BytesIO
+except ImportError:
+    from io import BytesIO
+
+try:
+    from urllib import quote
+except ImportError:
+    from urllib.parse import quote
+
+import base64
+
+import matplotlib
+from matplotlib import pyplot as plt
+from IPython.core.debugger import Tracer
+
+
+def sb_cutz(x, bins=10):
+    return pd.cut(x.rank(method='min', pct=True), bins=np.linspace(0, 1, bins + 1))
+
+
+def plot_confusion_matrix(cm, y, title='Univariate Confusion matrix', cmap=plt.cm.Blues):
+    plot = plt.figure(figsize=(6, 4))
+    #plot.subplots_adjust(left=0.15, right=0.95, top=0.9, bottom=0.1, wspace=0, hspace=0)
+    plt.imshow(cm, interpolation='nearest', cmap=cmap)
+    plt.title(title)
+    plt.colorbar()
+    tick_marks = np.arange(len(set(y)))
+    plt.xticks(tick_marks)
+    plt.yticks(tick_marks)
+    plt.tight_layout()
+    plt.ylabel('True label')
+    plt.xlabel('Predicted label')
+    ax = plt.gca()
+    ax.grid(False, which="majorminor")
+    return plot
+
+
+def mdl_1d(x, y):
+    """builds univariate model to calculate AUC"""
+    if x.nunique() > 10 and com.is_numeric_dtype(x):
+        x = sb_cutz(x)
+
+    series = pd.get_dummies(x, dummy_na=True)
+    lr = LogisticRegressionCV(scoring='roc_auc')
+
+    lr.fit(series, y)
+    try:
+        preds = (lr.predict_proba(series)[:, -1])
+        #preds = (preds > preds.mean()).astype(int)
+    except ValueError:
+        Tracer()()
+
+    try:
+        cm = confusion_matrix(y, (preds > y.mean()).astype(int))
+    except ValueError:
+        Tracer()()
+    plot = plot_confusion_matrix(cm, y)
+
+    imgdata = BytesIO()
+    plot.savefig(imgdata)
+    imgdata.seek(0)
+
+    aucz = roc_auc_score(y, preds)
+    cmatrix = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+    plt.close()
+    return aucz, cmatrix
+

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -27,7 +27,7 @@ def sb_cutz(x, bins=10):
     return pd.cut(x.rank(method='min', pct=True), bins=np.linspace(0, 1, bins + 1))
 
 
-def plot_confusion_matrix(cm, y, title='Univariate Confusion matrix', cmap=plt.cm.Blues):
+def plot_confusion_matrix(cm, y, title='Univariate Confusion Matrix', cmap=plt.cm.Blues):
     plot = plt.figure(figsize=(6, 4))
     #plot.subplots_adjust(left=0.15, right=0.95, top=0.9, bottom=0.1, wspace=0, hspace=0)
     plt.imshow(cm, interpolation='nearest', cmap=cmap)

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -2,8 +2,9 @@ import pandas as pd
 import numpy as np
 
 from sklearn.linear_model import LogisticRegressionCV
+from sklearn.linear_model import LassoLarsIC
 from sklearn.metrics import confusion_matrix, roc_auc_score
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 from pandas.core import common as com
 
 try:
@@ -47,6 +48,7 @@ def plot_confusion_matrix(cm, y, title='Univariate Confusion Matrix', cmap=plt.c
 def mdl_1d(x, y):
     """builds univariate model to calculate AUC"""
     lr = LogisticRegressionCV(scoring='roc_auc')
+    lars = LassoLarsIC(criterion='aic')
 
     if x.nunique() > 10 and com.is_numeric_dtype(x):
         x2 = sb_cutz(x)
@@ -55,6 +57,7 @@ def mdl_1d(x, y):
         series = pd.get_dummies(x, dummy_na=True)
 
     lr.fit(series, y)
+    lars.fit(series, y)
 
     try:
         preds = (lr.predict_proba(series)[:, -1])
@@ -67,76 +70,31 @@ def mdl_1d(x, y):
     #except ValueError:
     #    Tracer()()
 
+    aucz = roc_auc_score(y, preds)
+
     ns = num_bin_stats(x,y)
+
     nplot = plot_num(ns)
     #plot = plot_confusion_matrix(cm, y)
 
     imgdata = BytesIO()
     nplot.savefig(imgdata)
     imgdata.seek(0)
-
-    aucz = roc_auc_score(y, preds)
-    cmatrix = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+    nplot = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
     plt.close()
-    return aucz, cmatrix
 
-
-
-def plot_cat(series,y,title="Categorical Plot"):
-    y2=pd.Series(y)
-    tab = pd.concat([y2.groupby(series).count(),y2.groupby(series).mean()],axis=1)
-    tab.reset_index(inplace=True)
-    tab.columns = ['Value','Count','Mean(y)']
-    fign = plt.figure(figsize=(6, 4))
-    ax1 = fign.add_subplot(111)
-    ax1.bar(tab.index,tab['Count'],.5,color='b',align='center')
-    ax2 = ax1.twinx()
-    ax2.plot(tab.index,tab['Mean(y)'],'-r',linewidth=4)
-    plt.title(title)
-    #ax1.set_xlabel('Value')
-    ax1.set_xticks(tab.index)
-    ax1.set_xticklabels(tab['Value'], rotation=40, ha='right')
-    ax1.set_ylabel('Number of Observations',color='b')
-    ax2.set_ylabel('Mean(y)', color='r')
-    for t1 in ax1.get_yticklabels():
-        t1.set_color('b')  
-    for t2 in ax2.get_yticklabels():
-        t2.set_color('r')  
-    #plt.tight_layout()
-    return fign
-
-
-def mdl_1d_cat(x, y):
-    """builds univariate model to calculate AUC"""
-    if x.nunique() > 10 and com.is_numeric_dtype(x):
-        x = sb_cutz(x)
-
-    series = pd.get_dummies(x, dummy_na=True)
-    lr = LogisticRegressionCV(scoring='roc_auc')
-
-    lr.fit(series, y)
-
-    try:
-        preds = (lr.predict_proba(series)[:, -1])
-        #preds = (preds > preds.mean()).astype(int)
-    except ValueError:
-        Tracer()()
-
-    plot = plot_cat(x, y)
-
-    imgdata = BytesIO()
-    plot.savefig(imgdata)
-    imgdata.seek(0)
-
-    aucz = roc_auc_score(y, preds)
-    cmatrix = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+    bplot = plot_bubble(ns)
+    imgdatab = BytesIO()
+    bplot.savefig(imgdatab)
+    imgdatab.seek(0)
+    bplot = 'data:image/png;base64,' + quote(base64.b64encode(imgdatab.getvalue()))
     plt.close()
-    #print aucz, plot, cmatrix
-    return aucz, cmatrix
+
+    return aucz, nplot, bplot
 
 
 def plot_num(numstats):
-    fign = plt.figure(figsize=(6,4))
+    fign = plt.figure(figsize=(9,6))
     ax1 = fign.add_subplot(111)
     ax1.bar(numstats.index,numstats['Count'],.5,color='b',align='center')
     ax2 = ax1.twinx()
@@ -151,8 +109,21 @@ def plot_num(numstats):
         t1.set_color('b')  
     for t2 in ax2.get_yticklabels():
         t2.set_color('r')     
-    #plt.close()
     return fign
+
+
+def plot_bubble(numstats):
+    bubbles = numstats.loc[((numstats['bin'].apply(lambda x: str(x))!='MISS')&(numstats['bin'].apply(lambda x: str(x))!='ZERO'))].copy()
+    bubbles['bubsize']=bubbles['Count'].apply(lambda x: int((x/np.mean(bubbles['Count']))*200))
+    figb = plt.figure(figsize=(9,6))
+    plt.scatter(x=bubbles['Mean'],y=bubbles['Target_Rate'],s=bubbles['bubsize'],c='b',label='Pop Size')
+    plt.hold(True)
+    plt.plot(bubbles['Mean'],bubbles['Target_Rate'],'-r',linewidth=4,label='Target Rate')
+    plt.title("Relational Bubble Plot")
+    plt.xlabel('Mean Variable')
+    plt.ylabel('Target Rate',color='r')
+    plt.legend()
+    return figb
 
 
 def num_bucket_assign(data,var,bins):
@@ -245,22 +216,16 @@ def num_bin_stats(var,target,buckets=10,target_type='binary'):
        #test to see if fewer levels than buckets
     if len(temp['var'].unique())>buckets:        
         granular=1
-        
-        #create group buckets    
         cutpoints['bin'] = num_bucket_assign(temp,'var',buckets)
         
     else:        
         granular=0
-        
-        #create group buckets
         cutpoints['bin'] = list(temp['var'].unique())
         cutpoints['bin'].loc[cutpoints['bin'].isnull()]='MISS'
         cutpoints.sort_values(by='bin',inplace=True)
         cutpoints.reset_index(drop=True,inplace=True)
 
     for i in range(0,len(cutpoints)):
-        
-        #create series of values within bucket of interest
         if cutpoints['bin'][i]=='MISS':
             temp2 = temp.loc[temp['var'].isnull()]
         elif cutpoints['bin'][i]=='ZERO':
@@ -271,7 +236,6 @@ def num_bin_stats(var,target,buckets=10,target_type='binary'):
             else:
                 temp2 = temp.loc[temp['var']==cutpoints['bin'][i]]
         
-        #calculate key stats
         cutpoints['Count'].iloc[i] = len(temp2)
         cutpoints['Mean'].iloc[i] = np.mean(temp2['var'].apply(lambda x: float(x)))
         cutpoints['Miss_Target'].iloc[i] = sum(pd.isnull(temp2['target']))
@@ -284,3 +248,64 @@ def num_bin_stats(var,target,buckets=10,target_type='binary'):
             cutpoints['Mean_Target'].iloc[i] = np.mean(temp2['target'])
     
     return cutpoints
+
+
+
+def plot_cat(series,y,title="Categorical Plot",maxn = 10):
+    y2=pd.Series(y)
+    tab = pd.concat([y2.groupby(series).count(),y2.groupby(series).mean()],axis=1)
+    tab.columns = ['Count','Target']
+    tab.sort_values('Count',inplace=True,ascending=False)
+
+    if len(tab)>maxn:
+        short = tab[0:maxn].copy()
+        short.ix['Other'] = tab[maxn:len(tab)].sum()
+        tab = short.copy()
+
+    tab.reset_index(inplace=True)
+    tab.columns = ['Value','Count','Target']
+    tab['Mean(y)'] = tab['Target']/tab['Count']
+    fign = plt.figure(figsize=(9, 6))
+    ax1 = fign.add_subplot(111)
+    ax1.bar(tab.index,tab['Count'],.5,color='b',align='center')
+    ax2 = ax1.twinx()
+    ax2.plot(tab.index,tab['Mean(y)'],'-r',linewidth=4)
+    plt.title(title)
+    ax1.set_xticks(tab.index)
+    ax1.set_xticklabels(tab['Value'], rotation=40, ha='right')
+    ax1.set_ylabel('Number of Observations',color='b')
+    ax2.set_ylabel('Mean(y)', color='r')
+    for t1 in ax1.get_yticklabels():
+        t1.set_color('b')  
+    for t2 in ax2.get_yticklabels():
+        t2.set_color('r')  
+    #plt.tight_layout()
+    return fign
+
+
+def mdl_1d_cat(x, y):
+    """builds univariate model to calculate AUC"""
+    if x.nunique() > 10 and com.is_numeric_dtype(x):
+        x = sb_cutz(x)
+
+    series = pd.get_dummies(x, dummy_na=True)
+    lr = LogisticRegressionCV(scoring='roc_auc')
+
+    lr.fit(series, y)
+
+    try:
+        preds = (lr.predict_proba(series)[:, -1])
+        #preds = (preds > preds.mean()).astype(int)
+    except ValueError:
+        Tracer()()
+
+    plot = plot_cat(x, y)
+
+    imgdata = BytesIO()
+    plot.savefig(imgdata)
+    imgdata.seek(0)
+
+    aucz = roc_auc_score(y, preds)
+    cmatrix = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
+    plt.close()
+    return aucz, cmatrix

--- a/pandas_profiling/sb_utils/sb_univar.py
+++ b/pandas_profiling/sb_utils/sb_univar.py
@@ -46,35 +46,39 @@ def plot_confusion_matrix(cm, y, title='Univariate Confusion Matrix', cmap=plt.c
 
 def mdl_1d(x, y):
     """builds univariate model to calculate AUC"""
-    if x.nunique() > 10 and com.is_numeric_dtype(x):
-        x = sb_cutz(x)
-
-    series = pd.get_dummies(x, dummy_na=True)
     lr = LogisticRegressionCV(scoring='roc_auc')
 
+    if x.nunique() > 10 and com.is_numeric_dtype(x):
+        x2 = sb_cutz(x)
+        series = pd.get_dummies(x2, dummy_na=True)
+    else:
+        series = pd.get_dummies(x, dummy_na=True)
+
     lr.fit(series, y)
+
     try:
         preds = (lr.predict_proba(series)[:, -1])
         #preds = (preds > preds.mean()).astype(int)
     except ValueError:
         Tracer()()
 
-    try:
-        cm = confusion_matrix(y, (preds > y.mean()).astype(int))
-    except ValueError:
-        Tracer()()
+    #try:
+    #    cm = confusion_matrix(y, (preds > y.mean()).astype(int))
+    #except ValueError:
+    #    Tracer()()
 
-    plot = plot_confusion_matrix(cm, y)
+    ns = num_bin_stats(x,y)
+    nplot = plot_num(ns)
+    #plot = plot_confusion_matrix(cm, y)
 
     imgdata = BytesIO()
-    plot.savefig(imgdata)
+    nplot.savefig(imgdata)
     imgdata.seek(0)
 
     aucz = roc_auc_score(y, preds)
     cmatrix = 'data:image/png;base64,' + quote(base64.b64encode(imgdata.getvalue()))
     plt.close()
     return aucz, cmatrix
-
 
 
 
@@ -98,7 +102,7 @@ def plot_cat(series,y,title="Categorical Plot"):
         t1.set_color('b')  
     for t2 in ax2.get_yticklabels():
         t2.set_color('r')  
-    plt.tight_layout()
+    #plt.tight_layout()
     return fign
 
 
@@ -111,11 +115,11 @@ def mdl_1d_cat(x, y):
     lr = LogisticRegressionCV(scoring='roc_auc')
 
     lr.fit(series, y)
+
     try:
         preds = (lr.predict_proba(series)[:, -1])
         #preds = (preds > preds.mean()).astype(int)
     except ValueError:
-        print "preds error"
         Tracer()()
 
     plot = plot_cat(x, y)
@@ -129,3 +133,154 @@ def mdl_1d_cat(x, y):
     plt.close()
     #print aucz, plot, cmatrix
     return aucz, cmatrix
+
+
+def plot_num(numstats):
+    fign = plt.figure(figsize=(6,4))
+    ax1 = fign.add_subplot(111)
+    ax1.bar(numstats.index,numstats['Count'],.5,color='b',align='center')
+    ax2 = ax1.twinx()
+    ax2.plot(numstats.index,numstats['Target_Rate'],'-r',linewidth=4)
+    plt.title("Numeric Variable Univariate View")
+    ax1.set_xlabel(' bin')
+    ax1.set_xticks(numstats.index)
+    ax1.set_xticklabels(numstats['bin'], rotation=40, ha='right')
+    ax1.set_ylabel('Number of Observations',color='b')
+    ax2.set_ylabel('Target Rate', color='r')
+    for t1 in ax1.get_yticklabels():
+        t1.set_color('b')  
+    for t2 in ax2.get_yticklabels():
+        t2.set_color('r')     
+    #plt.close()
+    return fign
+
+
+def num_bucket_assign(data,var,bins):
+                
+    #find all unique values (Non-Missing) and sort in ascending sequence
+    temp = data[[var]].loc[data[var].notnull()]
+    
+    try:
+        temp['qcut_bins'] = pd.qcut(temp[var],10)
+        
+        v = temp['qcut_bins'].unique()
+        
+        #create data frame to include bin thresholds
+        b = pd.DataFrame(index=range(0,len(v)),columns=['bin'])
+        
+        for i in range(0,len(v)):
+            b['bin'].iloc[i]=(min(temp[var].loc[temp['qcut_bins']==v[i]]),
+                              max(temp[var].loc[temp['qcut_bins']==v[i]])) 
+        
+        bin_cuts=b.sort_values(by='bin').reset_index(drop=True)        
+        #print "           - qucut worked"
+        
+    except:    
+        #print "           - qucut failed"
+        u = temp[var].unique()
+
+        u.sort()
+        
+        #create data frame to include unique values, counts, and assigned buckets
+        uni = pd.DataFrame(index=range(0,len(u)),columns=['value','count','bucket'])
+        
+        #determine witdh of bucket based on number of obs
+        width = len(temp)/bins
+        
+        #initialize current bucket and bucket size count for loop
+        csize=0
+        bucket=0
+        
+        for i in range(0,len(u)):
+            #get unique value and count
+            uni['value'].iloc[i]=u[i]
+            uni['count'].iloc[i]=len(temp.loc[temp[var] == u[i]])
+    
+            #update size for current bucket and assign bucket value
+            csize=csize+uni['count'].iloc[i]
+            uni['bucket'].iloc[i]=bucket
+    
+            #if current bucket size has exceeded the desired width, then start next bucket
+            if csize>=width:
+                csize=0
+                bucket=bucket+1
+        
+        #merge small last bins into previous bin
+        if (np.sum(uni['count'][uni.bucket==max(uni['bucket'])])<(width/3)):
+            uni['bucket'].loc[uni['bucket']==max(uni['bucket'])]=max(uni['bucket'])-1
+        
+        #create data frame to include bin thresholds
+        bin_cuts = pd.DataFrame(index=range(0,max(uni['bucket'])+1),columns=['bin'])
+        
+        #assign min an max bucket values
+        for i in range(0,max(uni['bucket'])+1):
+            bin_cuts['bin'].iloc[i]=(min(uni.loc[uni['bucket']==i,'value']),max(uni.loc[uni['bucket']==i,'value'])) 
+        
+    #add bucket if missing values exist
+    if sum(pd.isnull(data[var]))>0:
+        bin_cuts.loc[len(bin_cuts)] = 'MISS'
+        
+    #add bucket if more than 1% of non missing values are =0
+    if (len(temp[var].loc[temp[var]==0])/float(len(temp)))>.01:
+        bin_cuts.loc[len(bin_cuts)] = 'ZERO'
+       
+    return bin_cuts
+
+
+def num_bin_stats(var,target,buckets=10,target_type='binary'):
+    
+    #create a temporary series to work with
+    temp = pd.DataFrame()
+    temp['var']=var
+    temp['target']=target
+    
+    #create summary dataframe for output
+    if target_type == 'binary':
+        cutpoints = pd.DataFrame(columns=('bin','Mean','Count','N_Target','Miss_Target','Target_Rate'))
+    elif target_type == 'continuous':
+        cutpoints = pd.DataFrame(columns=('bin','Mean','Count','Miss_Target','Mean_Target'))
+    else:
+        raise TypeError("Not a Valid Target Type (needs to be 'binary' or 'continuous')")
+     
+       #test to see if fewer levels than buckets
+    if len(temp['var'].unique())>buckets:        
+        granular=1
+        
+        #create group buckets    
+        cutpoints['bin'] = num_bucket_assign(temp,'var',buckets)
+        
+    else:        
+        granular=0
+        
+        #create group buckets
+        cutpoints['bin'] = list(temp['var'].unique())
+        cutpoints['bin'].loc[cutpoints['bin'].isnull()]='MISS'
+        cutpoints.sort_values(by='bin',inplace=True)
+        cutpoints.reset_index(drop=True,inplace=True)
+
+    for i in range(0,len(cutpoints)):
+        
+        #create series of values within bucket of interest
+        if cutpoints['bin'][i]=='MISS':
+            temp2 = temp.loc[temp['var'].isnull()]
+        elif cutpoints['bin'][i]=='ZERO':
+            temp2 = temp.loc[temp['var']==0]
+        else:
+            if granular==1:
+                temp2 = temp.loc[(temp['var']>=cutpoints['bin'].ix[i][0]) & (temp['var']<=cutpoints['bin'].ix[i][1])]
+            else:
+                temp2 = temp.loc[temp['var']==cutpoints['bin'][i]]
+        
+        #calculate key stats
+        cutpoints['Count'].iloc[i] = len(temp2)
+        cutpoints['Mean'].iloc[i] = np.mean(temp2['var'].apply(lambda x: float(x)))
+        cutpoints['Miss_Target'].iloc[i] = sum(pd.isnull(temp2['target']))
+        
+        if target_type == 'binary':
+            cutpoints['N_Target'].iloc[i] = sum(temp2['target'])
+            cutpoints['Target_Rate'].iloc[i] = cutpoints['N_Target'].iloc[i]/float(cutpoints['Count'].iloc[i])
+        
+        if target_type == 'continuous':
+            cutpoints['Mean_Target'].iloc[i] = np.mean(temp2['target'])
+    
+    return cutpoints

--- a/pandas_profiling/templates.py
+++ b/pandas_profiling/templates.py
@@ -309,10 +309,14 @@ overview_template= u'''
                         <td>{0[REJECTED]}</td></tr>
                         </tbody></table>
         </div>
+        <div class="col-md-12 text-right">
+                <a role="button" data-toggle="collapse" data-target="#warnings" aria-expanded="true" aria-controls="collapseExample">
+                    Toggle Warnings
+                </a>
+        </div>
         <div class="col-md-12" style="padding-left: 1em;">
             <p class="h4">Warnings</p>
-            <ul class="list-unstyled">{messages}</ul>
-        </div>
+                <ul id="warnings" class="list-unstyled">{messages}</ul></div>
      </div>
 '''
 

--- a/pandas_profiling/templates.py
+++ b/pandas_profiling/templates.py
@@ -508,13 +508,30 @@ row_templates_dict['NUM'] = _row_header.format(vartype="Numeric", varname="{0[va
                         <td>{0[memorysize]}</td></tr>
                  </table>
             </div>
-             <div class="col-sm-8 histogram">
-                 <img src="{0[histogram]}">
-             </div>
-             <div class="col-sm-8 histogram">
+            <div class="col-sm-8 histogram">
+                <img src="{0[histogram]}">
+            </div>
+        </div>
+
+             <div class="col-md-12 text-right">
+                <a role="button" data-toggle="collapse" data-target="#cmatrix{0[varid]}" aria-expanded="false" aria-controls="collapseExample">
+                    Toggle Plot
+                </a>
+            </div>
+
+             <div class="row collapse col-md-12" id="cmatrix{0[varid]}">
                  <img src="{0[cmatrix]}">
              </div>
- </div>
+
+             <div class="col-md-12 text-right">
+                <a role="button" data-toggle="collapse" data-target="#bplot{0[varid]}" aria-expanded="false" aria-controls="collapseExample">
+                    Toggle Bubble Plot
+                </a>
+            </div>
+
+             <div class="row collapse col-md-12" id="bplot{0[varid]}">
+                 <img src="{0[bplot]}">
+             </div>
 ''' + _row_footer
 
 row_templates_dict['DATE'] = _row_header.format(vartype="Date", varname="{0[varname]}", ft_dfn="{0[ft_dfn]}") + u'''
@@ -582,7 +599,7 @@ row_templates_dict['CAT'] = _row_header.format(vartype="Categorical", varname="{
 
         <div class="col-md-12 text-right">
                 <a role="button" data-toggle="collapse" data-target="#cmatrix{0[varid]}" aria-expanded="true" aria-controls="collapseExample">
-                    Toggle Confusion Matrix
+                    Toggle Plot
                 </a>
         </div>
         <div class="row collapse col-md-12" id="cmatrix{0[varid]}">

--- a/pandas_profiling/templates.py
+++ b/pandas_profiling/templates.py
@@ -258,8 +258,54 @@ wrapper_html = u'''
     <script>
        $(function () {
               $('[data-toggle="tooltip"]').tooltip()
-        })
+        });
     </script>
+    <script>
+        $(document).ready( function () {
+            function appender(index, val){
+                s = $('select')
+                $('<option />', {value: val, text: val.replace('varid_', '')}).appendTo(s);
+                };
+
+
+            var s = $('<select />');
+            var div_add_to = $('div.highlight').filter(function(index) { return this.textContent.match('Variables')});
+
+            s.appendTo($(div_add_to))
+            s.change(function (v) {$('#'+v.target.value).get(0).scrollIntoView()})
+
+            function popDropdown(){
+                s = $('select')
+                s.empty()
+
+                $('div.variablerow').each(
+                    function(idx, val){
+                    if (val.style['display'] != 'none'){
+                        if (val.id.length != 0){
+                            appender(idx, val.id)
+                            }
+                        }
+                    }
+                )
+            }
+
+            popDropdown()
+
+            $('#warnButton').click(function () {
+                 $('div.ignore').toggle()
+
+                popDropdown()
+
+                })
+
+	}
+	)
+
+        function scrollToTop() {
+            window.scrollTo(0, 0);
+        };
+    </script>
+
 </head>
 
 <body>
@@ -310,6 +356,13 @@ overview_template= u'''
                         </tbody></table>
         </div>
         <div class="col-md-12 text-right">
+        <!-- gosh dangit bobby -->
+                <a id='warnButton' role="button">
+                    Toggle Display of Ignored Variables
+                </a>
+        </div>
+
+        <div class="col-md-12 text-right">
                 <a role="button" data-toggle="collapse" data-target="#warnings" aria-expanded="true" aria-controls="collapseExample">
                     Toggle Warnings
                 </a>
@@ -320,18 +373,33 @@ overview_template= u'''
      </div>
 '''
 
-_row_header = u'''<div class="row variablerow">
-        <div class="col-md-3 namecol">
-            <p class="h4">
-                {varname}
-                <br/>
-                <small>{vartype}</small>
-                <br/>
-                <div style='font-size:13px'><p class="text-capitalize">{ft_dfn}</p></div>
-            </p>
-        </div>
+_row_header = u'''
+        <div class="row variablerow" id=varid_{varname}>
+            <div class="col-md-12 text-right">
+                <a role="button" onclick=scrollToTop()>
+                    Scroll to top
+                </a>
+            </div>
+
+            <div class="col-md-3 namecol">
+                <p class="h4">
+                    {varname}
+                    <br/>
+                    <small>{vartype}</small>
+                    <br/>
+                    <div style='font-size:13px'><p class="text-capitalize">{ft_dfn}</p></div>
+                </p>
+            </div>
+
 '''
-_row_header_ignore = u'''<div class="row variablerow ignore">
+_row_header_ignore = u'''
+        <div class="row variablerow ignore" id=varid_{varname}>
+            <div class="col-md-12 text-right">
+                <a role="button" onclick=scrollToTop()>
+                    Scroll to top
+                </a>
+            </div>
+
         <div class="col-md-3 namecol">
             <p class="h4">
                 <s>{varname}</s>
@@ -390,7 +458,7 @@ row_templates_dict['NUM'] = _row_header.format(vartype="Numeric", varname="{0[va
         </div>
        <div class="col-md-12 text-right">
             <a role="button" data-toggle="collapse" data-target="#descriptives{0[varid]},#minihistogram{0[varid]}" aria-expanded="false" aria-controls="collapseExample">
-                Toggle details
+                Toggle Details
             </a>
         </div>
         <div class="row collapse col-md-12" id="descriptives{0[varid]}">
@@ -507,10 +575,19 @@ row_templates_dict['CAT'] = _row_header.format(vartype="Categorical", varname="{
 
         <div class="col-md-12 text-right">
                 <a role="button" data-toggle="collapse" data-target="#freqtable{0[varid]}, #minifreqtable{0[varid]}" aria-expanded="true" aria-controls="collapseExample">
-                    Toggle details
+                    Toggle Details
                 </a>
         </div>
          {0[freqtable]}
+
+        <div class="col-md-12 text-right">
+                <a role="button" data-toggle="collapse" data-target="#cmatrix{0[varid]}" aria-expanded="true" aria-controls="collapseExample">
+                    Toggle Confusion Matrix
+                </a>
+        </div>
+        <div class="row collapse col-md-12" id="cmatrix{0[varid]}">
+            <img src="{0[cmatrix]}">
+        </div>
 ''' + _row_footer
 
 row_templates_dict['UNIQUE'] = _row_header.format(vartype="Categorical, Unique", varname="{0[varname]}", ft_dfn="{0[ft_dfn]}") + u'''
@@ -518,7 +595,7 @@ row_templates_dict['UNIQUE'] = _row_header.format(vartype="Categorical, Unique",
         <div class="col-md-6 collapse in" id="minivalues{0[varid]}">{0[lastn]}</div>
         <div class="col-md-12 text-right">
             <a role="button" data-toggle="collapse" data-target="#values{0[varid]},#minivalues{0[varid]}" aria-expanded="false" aria-controls="collapseExample">
-                Toggle details
+                Toggle Details
             </a>
         </div>
         <div class="col-md-12 collapse" id="values{0[varid]}">

--- a/pandas_profiling/templates.py
+++ b/pandas_profiling/templates.py
@@ -322,19 +322,32 @@ overview_template= u'''
 
 _row_header = u'''<div class="row variablerow">
         <div class="col-md-3 namecol">
-            <p class="h4">{varname}<br/><small>{vartype}</small></p>
+            <p class="h4">
+                {varname}
+                <br/>
+                <small>{vartype}</small>
+                <br/>
+                <div style='font-size:13px'><p class="text-capitalize">{ft_dfn}</p></div>
+            </p>
         </div>
 '''
 _row_header_ignore = u'''<div class="row variablerow ignore">
         <div class="col-md-3 namecol">
-            <p class="h4"><s>{varname}</s><br/><small>{vartype}</small></p>
+            <p class="h4">
+                <s>{varname}</s>
+                <br/>
+                <small>{vartype}</small>
+                <br/>
+                <div style='font-size:13px'><p class="text-capitalize">{ft_dfn}</p></div>
+                <br/>
+            </p>
         </div>
 '''
 
 _row_footer = u'''    </div>'''
 
 row_templates_dict = {}
-row_templates_dict['NUM'] = _row_header.format(vartype="Numeric", varname="{0[varname]}") + u'''
+row_templates_dict['NUM'] = _row_header.format(vartype="Numeric", varname="{0[varname]}", ft_dfn="{0[ft_dfn]}") + u'''
         <div class="col-md-6">
             <div class="row">
                 <div class="col-sm-6">
@@ -365,6 +378,8 @@ row_templates_dict['NUM'] = _row_header.format(vartype="Numeric", varname="{0[va
                         <td>{0[max]}</td></tr>
                         <tr class="{row_classes[p_zeros]}"><th>Zeros (%)</th>
                         <td>{0[p_zeros]}</td></tr>
+                        <tr><th>Univariate AUC</th>
+                        <td>{0[AUC]}</td></tr>
                     </table>
                 </div>
             </div>
@@ -409,6 +424,8 @@ row_templates_dict['NUM'] = _row_header.format(vartype="Numeric", varname="{0[va
                         <td>{0[cv]}</td></tr>
                         <tr><th>Kurtosis</th>
                         <td>{0[kurtosis]}</td></tr>
+                        <tr><th>Mode</th>
+                        <td>{0[mode]}</td></tr>
                         <tr><th>Mean</th>
                         <td>{0[mean]}</td></tr>
                         <tr><th>MAD</th>
@@ -426,10 +443,13 @@ row_templates_dict['NUM'] = _row_header.format(vartype="Numeric", varname="{0[va
              <div class="col-sm-8 histogram">
                  <img src="{0[histogram]}">
              </div>
-      </div>
+             <div class="col-sm-8 histogram">
+                 <img src="{0[cmatrix]}">
+             </div>
+ </div>
 ''' + _row_footer
 
-row_templates_dict['DATE'] = _row_header.format(vartype="Date", varname="{0[varname]}") + u'''
+row_templates_dict['DATE'] = _row_header.format(vartype="Date", varname="{0[varname]}", ft_dfn="{0[ft_dfn]}") + u'''
         <div class="col-sm-3">
             <table class="stats ">
                 <tr><th>Distinct count</th>
@@ -460,7 +480,7 @@ row_templates_dict['DATE'] = _row_header.format(vartype="Date", varname="{0[varn
 
 row_templates_dict['DISCRETE'] = row_templates_dict['NUM']
 
-row_templates_dict['CAT'] = _row_header.format(vartype="Categorical", varname="{0[varname]}") + u'''
+row_templates_dict['CAT'] = _row_header.format(vartype="Categorical", varname="{0[varname]}", ft_dfn="{0[ft_dfn]}") + u'''
        <div class="col-md-3">
 
             <table class="stats ">
@@ -476,6 +496,8 @@ row_templates_dict['CAT'] = _row_header.format(vartype="Categorical", varname="{
                 <td>{0[p_infinite]}</td></tr>
                 <tr class="{row_classes[p_infinite]}"><th>Infinite (n)</th>
                 <td>{0[n_infinite]}</td></tr>
+                <tr><th>Univariate AUC</th>
+                <td>{0[AUC]}</td></tr>
             </table>
 
 
@@ -491,7 +513,7 @@ row_templates_dict['CAT'] = _row_header.format(vartype="Categorical", varname="{
          {0[freqtable]}
 ''' + _row_footer
 
-row_templates_dict['UNIQUE'] = _row_header.format(vartype="Categorical, Unique", varname="{0[varname]}") + u'''
+row_templates_dict['UNIQUE'] = _row_header.format(vartype="Categorical, Unique", varname="{0[varname]}", ft_dfn="{0[ft_dfn]}") + u'''
         <div class="col-md-3 collapse in" id="minivalues{0[varid]}">{0[firstn]}</div>
         <div class="col-md-6 collapse in" id="minivalues{0[varid]}">{0[lastn]}</div>
         <div class="col-md-12 text-right">
@@ -508,7 +530,7 @@ row_templates_dict['UNIQUE'] = _row_header.format(vartype="Categorical, Unique",
 
 ''' + _row_footer
 
-row_templates_dict['CONST'] = _row_header_ignore.format(vartype="Constant", varname="{0[varname]}") + u'''
+row_templates_dict['CONST'] = _row_header_ignore.format(vartype="Constant", varname="{0[varname]}", ft_dfn="{0[ft_dfn]}") + u'''
          <div class="col-md-3">
             <p> <em>This variable is constant and should be ignored for analysis</em></p>
 
@@ -521,7 +543,7 @@ row_templates_dict['CONST'] = _row_header_ignore.format(vartype="Constant", varn
         </div>
 ''' + _row_footer
 
-row_templates_dict['CORR'] = _row_header_ignore.format(vartype="Highly correlated", varname="{0[varname]}") + u'''
+row_templates_dict['CORR'] = _row_header_ignore.format(vartype="Highly correlated", varname="{0[varname]}", ft_dfn="{0[ft_dfn]}") + u'''
          <div class="col-md-3">
             <p> <em>This variable is highly correlated with {0[correlation_var]} and should be ignored for analysis</em></p>
 

--- a/pandas_profiling/templates.py
+++ b/pandas_profiling/templates.py
@@ -4,9 +4,9 @@
 This file contains all templates used for generating the HTML profile report
 '''
 
-#TODO: rewrite this using Jinja template language
+# TODO: rewrite this using Jinja template language
 
-base_html=u'''
+base_html = u'''
     <meta charset="UTF-8">
 
     <style>
@@ -323,7 +323,7 @@ sample_html = u'''
     </div>
 '''
 
-overview_template= u'''
+overview_template = u'''
     <div class="row variablerow">
         <div class="col-md-6 namecol">
             <p class="h4">Dataset info</p>
@@ -678,14 +678,20 @@ freq_table_row = u'''
 </tr>
 '''
 
-messages=dict()
-messages['CONST'] = u'{0[varname]} has constant value {0[mode]} <span class="label label-primary">Rejected</span>'
-messages['CORR'] = u'{0[varname]} is highly correlated with {0[correlation_var]} (ρ = {0[correlation]}) <span class="label label-primary">Rejected</span>'
-messages['HIGH_CARDINALITY'] = u'{varname} has a high cardinality: {0[distinct_count]} distinct values  <span class="label label-warning">Warning</span>'
-messages['n_duplicates'] = u'Dataset has {0[n_duplicates]} duplicate rows <span class="label label-warning">Warning</span>'
+messages = dict()
+messages[
+    'CONST'] = u'{0[varname]} has constant value {0[mode]} <span class="label label-primary">Rejected</span>'
+messages[
+    'CORR'] = u'{0[varname]} is highly correlated with {0[correlation_var]} (ρ = {0[correlation]}) <span class="label label-primary">Rejected</span>'
+messages[
+    'HIGH_CARDINALITY'] = u'{varname} has a high cardinality: {0[distinct_count]} distinct values  <span class="label label-warning">Warning</span>'
+messages[
+    'n_duplicates'] = u'Dataset has {0[n_duplicates]} duplicate rows <span class="label label-warning">Warning</span>'
 messages['skewness'] = u'{varname} is highly skewed (γ1 = {0[skewness]})'
-messages['p_missing'] = u'{varname} has {0[n_missing]} / {0[p_missing]} missing values <span class="label label-default">Missing</span>'
-messages['p_infinite'] = u'{varname} has {0[n_infinite]} / {0[p_infinite]} infinite values <span class="label label-default">Infinite</span>'
+messages[
+    'p_missing'] = u'{varname} has {0[n_missing]} / {0[p_missing]} missing values <span class="label label-default">Missing</span>'
+messages[
+    'p_infinite'] = u'{varname} has {0[n_infinite]} / {0[p_infinite]} infinite values <span class="label label-default">Infinite</span>'
 messages['p_zeros'] = u'{varname} has {0[n_zeros]} / {0[p_zeros]} zeros'
 
 message_row = u'<li>{message}</l>'

--- a/pandas_profiling/tests.py
+++ b/pandas_profiling/tests.py
@@ -17,7 +17,7 @@ check_is_NaN = "pandas_profiling.check_is_NaN"
 class DataFrameTest(unittest.TestCase):
 
     def setUp(self):
-        self.data = {'id': [chr(97+c) for c in range(1,10)],
+        self.data = {'id': [chr(97 + c) for c in range(1, 10)],
                      'x': [50, 50, -10, 0, 0, 5, 15, -3, None],
                      'y': [0, 0, 0, 0, 1, 1, 1, 1, 0],
                      'zz': [0.000001, 654.152, None, 15.984512, 3122, -3.1415926535, 111, 15.9, 13.5],
@@ -28,19 +28,17 @@ class DataFrameTest(unittest.TestCase):
                      's2': [u'some constant text $ % value {obj} ' for _ in range(1, 10)],
                      'somedate': [datetime.date(2011, 7, 4), datetime.datetime(2022, 1, 1, 13, 57),
                                   datetime.datetime(1990, 12, 9), None,
-                                  datetime.datetime(1990, 12, 9), datetime.datetime(1950, 12, 9),
-                                  datetime.datetime(1898, 1, 2), datetime.datetime(1950, 12, 9)
-                         , datetime.datetime(1950, 12, 9)]}
+                                  datetime.datetime(
+                                      1990, 12, 9), datetime.datetime(1950, 12, 9),
+                                  datetime.datetime(1898, 1, 2), datetime.datetime(1950, 12, 9), datetime.datetime(1950, 12, 9)]}
         self.df = pd.DataFrame(self.data)
         self.df['somedate'] = pd.to_datetime(self.df['somedate'])
 
         self.results = describe(self.df)
         self.test_dir = tempfile.mkdtemp()
 
-
     def tearDown(self):
         shutil.rmtree(self.test_dir)
-
 
     def test_describe_df(self):
 
@@ -101,28 +99,34 @@ class DataFrameTest(unittest.TestCase):
                                         'skewness': check_is_NaN, 'std': check_is_NaN, 'sum': check_is_NaN, 'top': check_is_NaN, 'type': 'DATE',
                                         'variance': check_is_NaN}
 
-        self.assertSetEqual(set(self.results.keys()), set(['table', 'variables', 'freq']))
-        self.assertSetEqual(set(self.results['freq'].keys()), set(self.data.keys()))
-        self.assertSetEqual(set(self.results['variables'].index), set(self.data.keys()))
+        self.assertSetEqual(set(self.results.keys()),
+                            set(['table', 'variables', 'freq']))
+        self.assertSetEqual(
+            set(self.results['freq'].keys()), set(self.data.keys()))
+        self.assertSetEqual(
+            set(self.results['variables'].index), set(self.data.keys()))
 
         self.assertTrue(set({'CAT': 1,
-                                       'CONST': 2,
-                                       'DATE': 1,
-                                       'NUM': 2,
-                                       'UNIQUE': 1,
-                                       'n': 9,
-                                       'n_duplicates': 0,
-                                       'nvar': 7,
-                                       }.items()).issubset(set(self.results['table'].items())))
+                             'CONST': 2,
+                             'DATE': 1,
+                             'NUM': 2,
+                             'UNIQUE': 1,
+                             'n': 9,
+                             'n_duplicates': 0,
+                             'nvar': 7,
+                             }.items()).issubset(set(self.results['table'].items())))
 
-        self.assertAlmostEqual(0.063492063492063489, self.results['table']['total_missing'], 7)
+        self.assertAlmostEqual(0.063492063492063489, self.results[
+                               'table']['total_missing'], 7)
         # Loop over variables
         for col in self.data.keys():
-            for k,v in six.iteritems(expected_results[col]):
+            for k, v in six.iteritems(expected_results[col]):
                 if v == check_is_NaN:
-                    self.assertTrue(np.isnan(self.results['variables'].loc[col][k]))
+                    self.assertTrue(
+                        np.isnan(self.results['variables'].loc[col][k]))
                 elif isinstance(v, float):
-                    self.assertAlmostEqual(v, self.results['variables'].loc[col][k], 7)
+                    self.assertAlmostEqual(
+                        v, self.results['variables'].loc[col][k], 7)
                 else:
                     self.assertEqual(v, self.results['variables'].loc[col][k])
 
@@ -131,7 +135,6 @@ class DataFrameTest(unittest.TestCase):
                                 "Histogram missing for column %s " % col)
                 self.assertLess(200, len(self.results['variables'].loc[col]["mini_histogram"]),
                                 "Mini-histogram missing for column %s " % col)
-
 
     def test_html_report(self):
         html = to_html(self.df.head(), self.results)
@@ -147,7 +150,7 @@ class DataFrameTest(unittest.TestCase):
         filename = os.path.join(self.test_dir, "profile_%s.html" % hash(self))
         p.to_file(outputfile=filename)
 
-        self.assertLess(200,os.path.getsize(filename))
+        self.assertLess(200, os.path.getsize(filename))
 
 if __name__ == '__main__':
     unittest.main()

--- a/pandas_profiling/tests.py
+++ b/pandas_profiling/tests.py
@@ -19,7 +19,8 @@ class DataFrameTest(unittest.TestCase):
     def setUp(self):
         self.data = {'id': [chr(97+c) for c in range(1,10)],
                      'x': [50, 50, -10, 0, 0, 5, 15, -3, None],
-                     'y': [0.000001, 654.152, None, 15.984512, 3122, -3.1415926535, 111, 15.9, 13.5],
+                     'y': [0, 0, 0, 0, 1, 1, 1, 1, 0],
+                     'zz': [0.000001, 654.152, None, 15.984512, 3122, -3.1415926535, 111, 15.9, 13.5],
                      'cat': ['a', 'long text value', u'Élysée', '', None, 'some <b> B.s </div> </div> HTML stuff', 'c',
                              'c',
                              'c'],

--- a/sb_ci_test.py
+++ b/sb_ci_test.py
@@ -1,0 +1,32 @@
+import pandas_profiling as ppf
+from pandas_profiling import tests
+import pdb
+import numpy as np
+
+np.random.seed(96094)
+
+print('BRO U DUMB AF ASK RANDY HOW TO DO THIS FOR REAL FAM')
+
+try:
+    dft = tests.DataFrameTest()
+
+    dft.setUp()
+    dft.df['yy'] = np.random.randint(2, size=dft.df.shape[0])
+
+    stupid_temp = '/var/folders/0z/p07mwyl56bs98_jv_2ddby2c0000gn/T/tmpz1b175bv/lol.html'
+    stupid_temp2 = '/var/folders/0z/p07mwyl56bs98_jv_2ddby2c0000gn/T/tmpz1b175bv/lol2.html'
+
+    # run once with all the extras
+    profz = ppf.ProfileReport(dft.df, y='yy', corr_threshold=69, ft_names={'x': 'Yeezusss'})
+
+    profz.to_file(stupid_temp)
+
+    # run with just the base parameters
+    profz = ppf.ProfileReport(dft.df)
+    profz.to_file(stupid_temp2)
+
+    print('=' * 50)
+    print(stupid_temp)
+    print(stupid_temp2)
+except:
+    pdb.set_trace()

--- a/sb_ci_test.py
+++ b/sb_ci_test.py
@@ -8,7 +8,11 @@ np.random.seed(96094)
 print('BRO U DUMB AF ASK RANDY HOW TO DO THIS FOR REAL FAM')
 
 try:
-    dft = tests.DataFrameTest()
+    try:
+        dft = tests.DataFrameTest()
+    except:
+        tests.DataFrameTest.runTest = lambda x: 'fuk py2'
+        dft = tests.DataFrameTest()
 
     dft.setUp()
     dft.df['yy'] = np.random.randint(2, size=dft.df.shape[0])

--- a/sb_ci_test.py
+++ b/sb_ci_test.py
@@ -17,8 +17,8 @@ try:
     dft.setUp()
     dft.df['yy'] = np.random.randint(2, size=dft.df.shape[0])
 
-    stupid_temp = '/var/folders/0z/p07mwyl56bs98_jv_2ddby2c0000gn/T/tmpz1b175bv/lol.html'
-    stupid_temp2 = '/var/folders/0z/p07mwyl56bs98_jv_2ddby2c0000gn/T/tmpz1b175bv/lol2.html'
+    stupid_temp = '/tmp/lol.html'
+    stupid_temp2 = '/tmp/lol2.html'
 
     # run once with all the extras
     profz = ppf.ProfileReport(dft.df, y='yy', corr_threshold=69, ft_names={'x': 'Yeezusss'})
@@ -32,5 +32,6 @@ try:
     print('=' * 50)
     print(stupid_temp)
     print(stupid_temp2)
-except:
+except Exception as e:
+    print(e)
     pdb.set_trace()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 
 __location__ = os.path.dirname(__file__)
+print(__location__, __file__)
 
 try:
     from setuptools import setup
@@ -13,12 +14,16 @@ setup(
     author='Jos Polfliet',
     author_email='jos.polfliet+panpro@gmail.com',
     packages=['pandas_profiling'],
+    #package_dir={'pandas_profiling': './pandas_profiling'},
     url='http://github.com/jospolfliet/pandas-profiling',
     license='MIT',
     description='Generate profile report for pandas DataFrame',
     install_requires=[
         "pandas>=0.16",
-        "matplotlib>=1.4"
+        "matplotlib>=1.4",
+        "seaborn",
+        "scikit-learn",
+        "six"
     ],
     include_package_data = True,
     classifiers=[

--- a/updates_list.txt
+++ b/updates_list.txt
@@ -1,0 +1,21 @@
+updates list
+
+categorical columns
+-fix for columns with too many values, don't plot or plot top categories
+
+numeric columns
+-binning
+-binned mean plots
+-bubble plots
+-update html to toggle each plot separately
+
+date columns
+-auto parse for dates
+-timeline view?
+
+-paralell processing to speed up run time
+
+-simplify execution (to html and auc sorting)
+
+-review AUC methodology for high cardinal categoricals
+-add data sampling for large datasets when running AUC

--- a/updates_list.txt
+++ b/updates_list.txt
@@ -4,8 +4,6 @@ categorical columns
 -fix for columns with too many values, don't plot or plot top categories
 
 numeric columns
--binning
--binned mean plots
 -bubble plots
 -update html to toggle each plot separately
 
@@ -13,9 +11,12 @@ date columns
 -auto parse for dates
 -timeline view?
 
+-get tight layout working so plots don't look terrible
+
 -paralell processing to speed up run time
 
 -simplify execution (to html and auc sorting)
 
 -review AUC methodology for high cardinal categoricals
+
 -add data sampling for large datasets when running AUC

--- a/updates_list.txt
+++ b/updates_list.txt
@@ -1,15 +1,6 @@
 updates list
 
-categorical columns
--fix for columns with too many values, don't plot or plot top categories
-
-numeric columns
--bubble plots
--update html to toggle each plot separately
-
-date columns
--auto parse for dates
--timeline view?
+-find a useful plot for date variables, maybe a timeline view?
 
 -get tight layout working so plots don't look terrible
 
@@ -18,5 +9,6 @@ date columns
 -simplify execution (to html and auc sorting)
 
 -review AUC methodology for high cardinal categoricals
+-try different methods for sorting ... maybe a penalized metric like AIC/BIC
 
 -add data sampling for large datasets when running AUC

--- a/updates_list.txt
+++ b/updates_list.txt
@@ -12,3 +12,5 @@ updates list
 -try different methods for sorting ... maybe a penalized metric like AIC/BIC
 
 -add data sampling for large datasets when running AUC
+
+-plotting for 'miss' for categoricals


### PR DESCRIPTION
The corr_threshold parameter can be used to set the cutoff for variables to be analyzed by the profiler, e.g. a corr_threshold of 1 will analyze all variables regardless of any high correlations pairs, and a corr_threshold .5 will only analyze one variable in a pair of variables with correlation > .5.

I added a toggle to display warnings to html generated output:
![image](https://cloud.githubusercontent.com/assets/6711906/16845751/0705f3f2-49b8-11e6-91d6-ee0daa617aa7.png)

vs

![image](https://cloud.githubusercontent.com/assets/6711906/16845767/12eb7872-49b8-11e6-9845-a124300f33ff.png)
