### PR TITLE
Add LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
+include LICENSE
 include pandas_profiling/*.mplstyle
 include pandas_profiling/templates/*.html
+include README.md


### PR DESCRIPTION
Add the license (and readme) to MANIFEST.in so that they will be included in sdists and other packages. This came up during packaging of pandas-profiling for [conda-forge](https://conda-forge.github.io/).