### PR TITLE
added call to pool.close() in describe_1d

### DIFF
--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -447,6 +447,7 @@ def describe(df, bins=10, correlation_overrides=None, pool_size=multiprocessing.
     pool = multiprocessing.Pool(pool_size)
     local_multiprocess_func = partial(multiprocess_func, **kwargs)
     ldesc = {col: s for col, s in pool.map(local_multiprocess_func, df.iteritems())}
+    pool.close()
 
     # Check correlations between variables
     ''' TODO: corr(x,y) > 0.9 and corr(y,z) > 0.9 does not imply corr(x,z) > 0.9


### PR DESCRIPTION
Thanks for this module. It's saved me a lot of time in working on a script for profiling databases.

In running this inside another python script on multiple tables in a database I would encounter "too many files open" error after it processed enough columns. The problem seems to be the threads were staying open and in turn keeping a file descriptor open. Once enough threads had been started it would hit the OS's limit on open files.

This additional line should fix the problem.