### PR TITLE
Add keyword arg to not check correlation.

### DIFF
--- a/pandas_profiling/tests.py
+++ b/pandas_profiling/tests.py
@@ -166,6 +166,11 @@ class CategoricalDataTest(unittest.TestCase):
         for key in expected_results:
             self.assertEqual(self.results['table'][key], expected_results[key])
 
+        # Rerun without checking for correlation
+        self.results2 = describe(self.df, check_correlation=False)
+        self.assertIsNone(self.results2['variables'].loc['x'].get('correlation_var'))
+        self.assertEqual(self.results2['table']['REJECTED'], 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Thanks for this package. We are evaluating it for project and finding it suits our needs. 

In our use case we want to profile rather large database tables. We found that the correlation checks can use a lot of memory causing the process to fail. Since this check isn't critical to this use case, we would simply like to skip these checks when profiling. 

This pull request adds a keyword argument to `describe` called `check_correlation` that defaults to `True`. If `False` is passed, then the correlation checks aren't run. 