### PR TITLE
Fixed issue #56

### DIFF
--- a/pandas_profiling/base.py
+++ b/pandas_profiling/base.py
@@ -220,7 +220,7 @@ def describe_1d(data, **kwargs):
                     'n_infinite': n_infinite,
                     'is_unique': distinct_count == leng,
                     'mode': mode,
-                    'p_unique': distinct_count / count}
+                    'p_unique': distinct_count / leng}
     try:
         # pandas 0.17 onwards
         results_data['memorysize'] = data.memory_usage()

--- a/pandas_profiling/tests.py
+++ b/pandas_profiling/tests.py
@@ -5,9 +5,11 @@ import unittest
 import datetime
 import numpy as np
 import pandas as pd
+from pandas import Series
 import six
 import pandas_profiling
 from pandas_profiling.base import describe, to_html
+import base
 import tempfile
 import shutil
 import os
@@ -17,7 +19,7 @@ check_is_NaN = "pandas_profiling.check_is_NaN"
 class DataFrameTest(unittest.TestCase):
 
     def setUp(self):
-        self.data = {'id': [chr(97+c) for c in range(1,10)],
+        self.data = {'id': [chr(97 + c) for c in range(1, 10)],
                      'x': [50, 50, -10, 0, 0, 5, 15, -3, None],
                      'y': [0.000001, 654.152, None, 15.984512, 3122, -3.1415926535, 111, 15.9, 13.5],
                      'cat': ['a', 'long text value', u'Élysée', '', None, 'some <b> B.s </div> </div> HTML stuff', 'c',
@@ -27,19 +29,17 @@ class DataFrameTest(unittest.TestCase):
                      's2': [u'some constant text $ % value {obj} ' for _ in range(1, 10)],
                      'somedate': [datetime.date(2011, 7, 4), datetime.datetime(2022, 1, 1, 13, 57),
                                   datetime.datetime(1990, 12, 9), np.nan,
-                                  datetime.datetime(1990, 12, 9), datetime.datetime(1950, 12, 9),
-                                  datetime.datetime(1898, 1, 2), datetime.datetime(1950, 12, 9)
-                         , datetime.datetime(1950, 12, 9)]}
+                                  datetime.datetime(
+                                      1990, 12, 9), datetime.datetime(1950, 12, 9),
+                                  datetime.datetime(1898, 1, 2), datetime.datetime(1950, 12, 9), datetime.datetime(1950, 12, 9)]}
         self.df = pd.DataFrame(self.data)
         self.df['somedate'] = pd.to_datetime(self.df['somedate'])
 
         self.results = describe(self.df)
         self.test_dir = tempfile.mkdtemp()
 
-
     def tearDown(self):
         shutil.rmtree(self.test_dir)
-
 
     def test_describe_df(self):
 
@@ -54,7 +54,7 @@ class DataFrameTest(unittest.TestCase):
                                  'count': 8, 'n_infinite': 0, 'p_infinite': 0, 'cv': 1.771071190261633, 'distinct_count': 7, 'freq': check_is_NaN, 'iqr': 24.5,
                                  'is_unique': False, 'kurtosis': -0.50292858929003803, 'mad': 18.71875, 'max': 50.0,
                                  'mean': 13.375, 'min': -10.0, 'mode': 0.0, 'n_missing': 1,
-                                 'p_missing': 0.11111111111111116, 'p_unique': 0.875, 'p_zeros': 0.2222222222222222,
+                                 'p_missing': 0.11111111111111116, 'p_unique': 7/9, 'p_zeros': 0.2222222222222222,
                                  'range': 60.0, 'skewness': 1.0851622393567653, 'std': 23.688077169749342, 'sum': 107.0,
                                  'top': check_is_NaN, 'type': 'NUM', 'variance': 561.125}
         expected_results['y'] = {'25%': 10.125000249999999, '5%': -2.0420348747749997, '50%': 15.942256,
@@ -63,7 +63,7 @@ class DataFrameTest(unittest.TestCase):
                                  'iqr': 236.66299975000001, 'is_unique': True, 'kurtosis': 6.974137018717359,
                                  'mad': 698.45081747834365, 'max': 3122.0, 'mean': 491.17436504331249,
                                  'min': -3.1415926535000001, 'mode': 9.9999999999999995e-07, 'n_missing': 1,
-                                 'p_missing': 0.11111111111111116, 'p_unique': 1.125, 'p_zeros': 0.0,
+                                 'p_missing': 0.11111111111111116, 'p_unique': 1, 'p_zeros': 0.0,
                                  'range': 3125.1415926535001, 'skewness': 2.6156591135729266, 'std': 1086.1335236468506,
                                  'sum': 3929.3949203464999, 'top': check_is_NaN, 'type': 'NUM',
                                  'variance': 1179686.0311895239}
@@ -71,7 +71,7 @@ class DataFrameTest(unittest.TestCase):
                                    'cv': check_is_NaN, 'distinct_count': 7, 'freq': 3, 'histogram': check_is_NaN, 'iqr': check_is_NaN,
                                    'is_unique': False, 'kurtosis': check_is_NaN, 'mad': check_is_NaN, 'max': check_is_NaN, 'mean': check_is_NaN,
                                    'min': check_is_NaN, 'mini_histogram': check_is_NaN, 'mode': 'c',
-                                   'n_missing': 1, 'p_missing': 0.11111111111111116, 'p_unique': 0.875,
+                                   'n_missing': 1, 'p_missing': 0.11111111111111116, 'p_unique': 7/9,
                                    'p_zeros': check_is_NaN, 'range': check_is_NaN, 'skewness': check_is_NaN, 'std': check_is_NaN, 'sum': check_is_NaN,
                                    'top': 'c', 'type': 'CAT', 'variance': check_is_NaN}
         expected_results['s1'] = {'25%': check_is_NaN, '5%': check_is_NaN, '50%': check_is_NaN, '75%': check_is_NaN, '95%': check_is_NaN, 'count': 9, 'n_infinite': 0, 'p_infinite': 0,
@@ -95,14 +95,17 @@ class DataFrameTest(unittest.TestCase):
                                         'mad': check_is_NaN, 'max': datetime.datetime(2022, 1, 1, 13, 57), 'mean': check_is_NaN,
                                         'min': datetime.datetime(1898, 1, 2),
                                         'mode': datetime.datetime(1950, 12, 9),
-                                        'n_missing': 1, 'p_missing': 0.11111111111111116, 'p_unique': 0.75,
+                                        'n_missing': 1, 'p_missing': 0.11111111111111116, 'p_unique': 6/9,
                                         'p_zeros': check_is_NaN, 'range': datetime.timedelta(45289, hours=13, minutes=57),
                                         'skewness': check_is_NaN, 'std': check_is_NaN, 'sum': check_is_NaN, 'top': check_is_NaN, 'type': 'DATE',
                                         }
 
-        self.assertSetEqual(set(self.results.keys()), set(['table', 'variables', 'freq']))
-        self.assertSetEqual(set(self.results['freq'].keys()), set(self.data.keys()))
-        self.assertSetEqual(set(self.results['variables'].index), set(self.data.keys()))
+        self.assertSetEqual(set(self.results.keys()),
+                            set(['table', 'variables', 'freq']))
+        self.assertSetEqual(
+            set(self.results['freq'].keys()), set(self.data.keys()))
+        self.assertSetEqual(
+            set(self.results['variables'].index), set(self.data.keys()))
 
         self.assertTrue(set({'CAT': 1,
                                        'CONST': 2,
@@ -114,14 +117,17 @@ class DataFrameTest(unittest.TestCase):
                                        'nvar': 7,
                                        }.items()).issubset(set(self.results['table'].items())))
 
-        self.assertAlmostEqual(0.063492063492063489, self.results['table']['total_missing'], 7)
+        self.assertAlmostEqual(0.063492063492063489,
+                               self.results['table']['total_missing'], 7)
         # Loop over variables
         for col in self.data.keys():
-            for k,v in six.iteritems(expected_results[col]):
+            for k, v in six.iteritems(expected_results[col]):
                 if v == check_is_NaN:
-                    self.assertTrue(np.isnan(self.results['variables'].loc[col][k]), msg="Value {} for key {} in column {} is not NaN".format(self.results['variables'].loc[col][k], k, col))
+                    self.assertTrue(np.isnan(self.results['variables'].loc[col][k]), msg="Value {} for key {} in column {} is not NaN".format(
+                        self.results['variables'].loc[col][k], k, col))
                 elif isinstance(v, float):
-                    self.assertAlmostEqual(v, self.results['variables'].loc[col][k], 7)
+                    self.assertAlmostEqual(
+                        v, self.results['variables'].loc[col][k], 7)
                 else:
                     self.assertEqual(v, self.results['variables'].loc[col][k])
 
@@ -130,7 +136,6 @@ class DataFrameTest(unittest.TestCase):
                                 "Histogram missing for column %s " % col)
                 self.assertLess(200, len(self.results['variables'].loc[col]["mini_histogram"]),
                                 "Mini-histogram missing for column %s " % col)
-
 
     def test_html_report(self):
         html = to_html(self.df.head(), self.results)
@@ -146,31 +151,58 @@ class DataFrameTest(unittest.TestCase):
         filename = os.path.join(self.test_dir, "profile_%s.html" % hash(self))
         p.to_file(outputfile=filename)
 
-        self.assertLess(200,os.path.getsize(filename))
+        self.assertLess(200, os.path.getsize(filename))
 
 
 class CategoricalDataTest(unittest.TestCase):
 
     def test_recoding_reject(self):
         self.data = {
-             'x': ['chien', 'chien', 'chien', 'chien', 'chat','chat','chameaux', 'chameaux'],
-             'y': ['dog', 'dog', 'dog', 'dog', 'cat','cat','camel','camel'],
+             'x': ['chien', 'chien', 'chien', 'chien', 'chat', 'chat', 'chameaux', 'chameaux'],
+             'y': ['dog', 'dog', 'dog', 'dog', 'cat', 'cat', 'camel', 'camel'],
            }
         self.df = pd.DataFrame(self.data)
         self.results = describe(self.df)
 
         self.assertEqual(self.results['variables'].loc['x']['type'], 'RECODED')
-        self.assertEqual(self.results['variables'].loc['x']['correlation_var'], 'y')
+        self.assertEqual(
+            self.results['variables'].loc['x']['correlation_var'], 'y')
 
-        expected_results = {'total_missing': 0.0, 'UNIQUE': 0, 'CONST': 0, 'nvar': 2, 'REJECTED': 1, 'n': 8, 'RECODED': 1, 'CORR': 0, 'DATE': 0, 'NUM': 0, 'CAT': 1, 'n_duplicates': 5}
+        expected_results = {'total_missing': 0.0, 'UNIQUE': 0, 'CONST': 0, 'nvar': 2, 'REJECTED': 1,
+            'n': 8, 'RECODED': 1, 'CORR': 0, 'DATE': 0, 'NUM': 0, 'CAT': 1, 'n_duplicates': 5}
         for key in expected_results:
             self.assertEqual(self.results['table'][key], expected_results[key])
 
         # Rerun without checking for correlation
         self.results2 = describe(self.df, check_correlation=False)
-        self.assertIsNone(self.results2['variables'].loc['x'].get('correlation_var'))
+        self.assertIsNone(
+            self.results2['variables'].loc['x'].get('correlation_var'))
         self.assertEqual(self.results2['table']['REJECTED'], 0)
 
+
+class Describe1dTest(unittest.TestCase):
+
+    def test_unique(self):
+        """Test the unique feature of 1D data"""
+        # Unique values
+        self._assert_unique(pd.Series([1, 2]), True, 1)
+        # Unique values all nan
+        self._assert_unique(pd.Series([np.nan]), True, 1)
+        # Unique values including nan
+        self._assert_unique(pd.Series([1, 2, np.nan]), True, 1)
+        # Non unique values
+        self._assert_unique(pd.Series([1, 2, 2]), False, 2/3)
+        # Non unique nan
+        self._assert_unique(pd.Series([1, np.nan, np.nan]), False, 2/3)
+        # Non unique values including nan
+        self._assert_unique(pd.Series([1, 2, 2, np.nan]), False, 3/4)
+        # Non unique values including non unique nan
+        self._assert_unique(pd.Series([1, 2, 2, np.nan, np.nan]), False, 3/5)
+
+    def _assert_unique(self, data, is_unique, p_unique):
+        desc_1d = base.describe_1d(data)
+        self.assertEqual(desc_1d['is_unique'], is_unique)
+        self.assertEqual(desc_1d['p_unique'], p_unique)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The current implementation includes na in distinct_count. But when the percentage of unique values is computed the distinct count is divided by the count that does not include na This is the cause of the inconsistent results highlighted in #56. I've fixed the implementation to be consistent: na is considered as a distinct value also in the percentage of unique values Another implementation would have been to not consider na at all. A specific test case has been added.