### PR TITLE
Instead of throwing an error check if the correlation was computed

### DIFF
--- a/pandas_profiling/__init__.py
+++ b/pandas_profiling/__init__.py
@@ -33,8 +33,8 @@ class ProfileReport(object):
             threshold: float (optional)
                 correlation value which is above the threshold are rejected
         """
-        variable_profile = self.description_set['variables']
-        return variable_profile.index[variable_profile.correlation > threshold].tolist()
+        variable_profile = self.description_set['variables']        
+        return variable_profile.index[variable_profile.correlation > threshold].tolist() if hasattr(variable_profile, 'correlation') else []
 
     def to_file(self, outputfile=DEFAULT_OUTPUTFILE):
 


### PR DESCRIPTION
This fixes issue #11. In his example, the dataset doesn't compute the correlation, so if the attribute doesn't exist, we should return an empty array.